### PR TITLE
Use the new ioctl to construct sysfs path to the afu

### DIFF
--- a/libcxl.c
+++ b/libcxl.c
@@ -25,6 +25,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <errno.h>
+#include <err.h>
 #include <stdio.h>
 #include <fcntl.h>
 #include <regex.h>
@@ -223,14 +224,37 @@ int cxl_afu_opened(struct cxl_afu_h *afu)
 
 static int cxl_sysfs_fd(char **bufp, struct cxl_afu_h *afu)
 {
+	struct cxl_afu_id afuid;
+	char suffix = '\0';
 	int fd = cxl_afu_fd(afu);
-	struct stat sb;
 
-	if (fstat(fd, &sb) < 0)
+	/* fetch the afu id via ioctl to the kernel driver */
+	if (ioctl(fd, CXL_IOCTL_GET_AFU_ID, &afuid) < 0) {
+		struct stat sb;
+
+		/* if the ioctl is not recognized, fallback to old method */
+		if ((errno != EINVAL) || (fstat(fd, &sb) < 0) ||
+		    !S_ISCHR(sb.st_mode))
+			return -1;
+
+		return asprintf(bufp, "/sys/dev/char/%i:%i", major(sb.st_rdev),
+				minor(sb.st_rdev));
+	}
+
+	switch (afuid.afu_mode) {
+	case CXL_MODE_DEDICATED:
+		suffix = 'd';
+		break;
+	case CXL_MODE_DIRECTED:
+		suffix = (afuid.flags & CXL_AFUID_FLAG_SLAVE) ? 's' : 'm';
+		break;
+	default:
+		errno = EINVAL;
 		return -1;
-	if (!S_ISCHR(sb.st_mode))
-		return -1;
-	return asprintf(bufp, "/sys/dev/char/%i:%i", major(sb.st_rdev), minor(sb.st_rdev));
+	}
+
+	return asprintf(bufp, "/sys/class/cxl/afu%i.%i%c", afuid.card_id,
+			afuid.afu_offset, suffix);
 }
 
 static int cxl_afu_sysfs(struct cxl_afu_h *afu, char **bufp)


### PR DESCRIPTION
This patch changes the cxl_sysfs_fd function to use new ioctl
CXL_IOCTL_GET_AFU_ID available on afu file descriptor to fetch the
cxl_afu_id structure containing the card/offset & mode information. This
info is then used to construct the path to the afu's sysfs
directory. Older implementation was dependent on the major/minor number
of the afu retrieved by fstat on the fd. However with new cxl kernel api
its possible for a kernel module to have its own device that exports
libcxl api to the userspace. This broke the existing implementation
which was dependent on the major/minor numbers fetched from the device
file.

If the ioctl is not available (in case of older cxl driver) the
implementation falls back to the previous mechanism of constructing the
sysfs path using the major/minor numbers retrieved by fstating the file
descriptor to the afu device.
