### PR TITLE
Export some missing symbols + small fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,8 +15,9 @@ CHECK_CXL_HEADER_IS_UP_TO_DATE = $(shell /bin/echo -e \\\#include $(1)\\\nvoid t
 
 check_cxl_header:
 ifeq ($(call CHECK_CXL_HEADER_IS_UP_TO_DATE,"<misc/cxl.h>"),n)
+	mkdir -p include/misc
 ifeq (${HAS_WGET},y)
-	$(call Q,WGET include/misc/cxl.h, mkdir -p include/misc && wget -O include/misc/cxl.h -q http://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/plain/include/uapi/misc/cxl.h)
+	$(call Q,WGET include/misc/cxl.h, wget -O include/misc/cxl.h -q http://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/plain/include/uapi/misc/cxl.h)
 else ifeq (${HAS_CURL},y)
 	$(call Q,CURL include/misc/cxl.h, curl -o include/misc/cxl.h -s http://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/plain/include/uapi/misc/cxl.h)
 else

--- a/Makefile
+++ b/Makefile
@@ -11,12 +11,12 @@ HAS_CURL = $(shell /bin/which curl > /dev/null 2>&1 && echo y || echo n)
 
 # Update this to test a single feature from the most recent header we require:
 CHECK_CXL_HEADER_IS_UP_TO_DATE = $(shell /bin/echo -e \\\#include $(1)\\\nvoid test\(struct cxl_afu_id test\)\; | \
-                 $(CC) $(CFLAGS) -Werror -x c -S - > /dev/null 2>&1 && echo y || echo n)
+                 $(CC) $(CFLAGS) -Werror -x c -S -o /dev/null - > /dev/null 2>&1 && echo y || echo n)
 
 check_cxl_header:
 ifeq ($(call CHECK_CXL_HEADER_IS_UP_TO_DATE,"<misc/cxl.h>"),n)
 ifeq (${HAS_WGET},y)
-	$(call Q,WGET include/misc/cxl.h, wget -O include/misc/cxl.h -q http://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/plain/include/uapi/misc/cxl.h)
+	$(call Q,WGET include/misc/cxl.h, mkdir -p include/misc && wget -O include/misc/cxl.h -q http://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/plain/include/uapi/misc/cxl.h)
 else ifeq (${HAS_CURL},y)
 	$(call Q,CURL include/misc/cxl.h, curl -o include/misc/cxl.h -s http://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/plain/include/uapi/misc/cxl.h)
 else

--- a/symver.map
+++ b/symver.map
@@ -61,3 +61,10 @@ LIBCXL_1 {
 	local:
 		*;
 };
+
+LIBCXL_1.1 {
+	global:
+		cxl_get_cr_class;
+		cxl_get_cr_device;
+		cxl_get_cr_vendor;
+} LIBCXL_1;


### PR DESCRIPTION
Makefile:
- get rid of annoying "-.s" file created by gcc
- wget fails if include/misc doesn't exist

symver.map:
- export cxl_get_cr_\* symbols
