### PR TITLE
cxl_work_attach, an alternative to cxl_attach_full

### DIFF
--- a/libcxl.c
+++ b/libcxl.c
@@ -644,6 +644,103 @@ int cxl_afu_attach_full(struct cxl_afu_h *afu, __u64 wed, __u16 num_interrupts,
 	return ioctl(afu->fd, CXL_IOCTL_START_WORK, &work);
 }
 
+struct cxl_ioctl_start_work *cxl_work_alloc()
+{
+	struct cxl_ioctl_start_work *work;
+
+	work = malloc(sizeof(struct cxl_ioctl_start_work));
+	if (work)
+		memset(work, 0, sizeof(struct cxl_ioctl_start_work));
+	return work;
+}
+
+int cxl_work_attach(struct cxl_ioctl_start_work* work, struct cxl_afu_h *afu)
+{
+	if (afu == NULL || afu->fd < 0 || work == NULL) {
+		errno = EINVAL;
+		return -1;
+	}
+	return ioctl(afu->fd, CXL_IOCTL_START_WORK, work);
+}
+
+int cxl_work_free(struct cxl_ioctl_start_work *work)
+{
+	if (work == NULL) {
+		errno = EINVAL;
+		return -1;
+	}
+	free(work);
+	return 0;
+}
+
+int cxl_work_get_amr(struct cxl_ioctl_start_work *work, __u64 *valp)
+{
+	if (work == NULL) {
+		errno = EINVAL;
+		return -1;
+	}
+	*valp = work->amr;
+	return 0;
+}
+
+int cxl_work_get_num_irqs(struct cxl_ioctl_start_work *work, __s16 *valp)
+{
+	if (work == NULL) {
+		errno = EINVAL;
+		return -1;
+	}
+	*valp = work->num_interrupts;
+	return 0;
+}
+
+int cxl_work_get_wed(struct cxl_ioctl_start_work *work, __u64 *valp)
+{
+	if (work == NULL) {
+		errno = EINVAL;
+		return -1;
+	}
+	*valp = work->work_element_descriptor;
+	return 0;
+}
+
+int cxl_work_set_amr(struct cxl_ioctl_start_work *work, __u64 amr)
+{
+	if (work == NULL) {
+		errno = EINVAL;
+		return -1;
+	}
+	work->amr = amr;
+	if (amr)
+		work->flags |= CXL_START_WORK_AMR;
+	else
+		work->flags &= ~(CXL_START_WORK_AMR);
+	return 0;
+}
+
+int cxl_work_set_num_irqs(struct cxl_ioctl_start_work *work, __s16 irqs)
+{
+	if (work == NULL) {
+		errno = EINVAL;
+		return -1;
+	}
+	work->num_interrupts = irqs;
+	if (irqs >= 0)
+		work->flags |= CXL_START_WORK_NUM_IRQS;
+	else
+		work->flags &= ~(CXL_START_WORK_NUM_IRQS);
+	return 0;
+}
+
+int cxl_work_set_wed(struct cxl_ioctl_start_work *work, __u64 wed)
+{
+	if (work == NULL) {
+		errno = EINVAL;
+		return -1;
+	}
+	work->work_element_descriptor = wed;
+	return 0;
+}
+
 /*
  * Event description print helpers
  */

--- a/libcxl.c
+++ b/libcxl.c
@@ -644,17 +644,9 @@ int cxl_afu_attach_full(struct cxl_afu_h *afu, __u64 wed, __u16 num_interrupts,
 	return ioctl(afu->fd, CXL_IOCTL_START_WORK, &work);
 }
 
-struct cxl_ioctl_start_work *cxl_work_alloc()
-{
-	struct cxl_ioctl_start_work *work;
-
-	work = malloc(sizeof(struct cxl_ioctl_start_work));
-	if (work)
-		memset(work, 0, sizeof(struct cxl_ioctl_start_work));
-	return work;
-}
-
-int cxl_work_attach(struct cxl_ioctl_start_work* work, struct cxl_afu_h *afu)
+inline
+int cxl_afu_attach_work(struct cxl_afu_h *afu,
+			struct cxl_ioctl_start_work *work)
 {
 	if (afu == NULL || afu->fd < 0 || work == NULL) {
 		errno = EINVAL;
@@ -663,6 +655,13 @@ int cxl_work_attach(struct cxl_ioctl_start_work* work, struct cxl_afu_h *afu)
 	return ioctl(afu->fd, CXL_IOCTL_START_WORK, work);
 }
 
+inline
+struct cxl_ioctl_start_work *cxl_work_alloc()
+{
+	return calloc(1, sizeof(struct cxl_ioctl_start_work));
+}
+
+inline
 int cxl_work_free(struct cxl_ioctl_start_work *work)
 {
 	if (work == NULL) {
@@ -673,6 +672,7 @@ int cxl_work_free(struct cxl_ioctl_start_work *work)
 	return 0;
 }
 
+inline
 int cxl_work_get_amr(struct cxl_ioctl_start_work *work, __u64 *valp)
 {
 	if (work == NULL) {
@@ -683,6 +683,7 @@ int cxl_work_get_amr(struct cxl_ioctl_start_work *work, __u64 *valp)
 	return 0;
 }
 
+inline
 int cxl_work_get_num_irqs(struct cxl_ioctl_start_work *work, __s16 *valp)
 {
 	if (work == NULL) {
@@ -693,6 +694,7 @@ int cxl_work_get_num_irqs(struct cxl_ioctl_start_work *work, __s16 *valp)
 	return 0;
 }
 
+inline
 int cxl_work_get_wed(struct cxl_ioctl_start_work *work, __u64 *valp)
 {
 	if (work == NULL) {
@@ -703,6 +705,7 @@ int cxl_work_get_wed(struct cxl_ioctl_start_work *work, __u64 *valp)
 	return 0;
 }
 
+inline
 int cxl_work_set_amr(struct cxl_ioctl_start_work *work, __u64 amr)
 {
 	if (work == NULL) {
@@ -717,6 +720,7 @@ int cxl_work_set_amr(struct cxl_ioctl_start_work *work, __u64 amr)
 	return 0;
 }
 
+inline
 int cxl_work_set_num_irqs(struct cxl_ioctl_start_work *work, __s16 irqs)
 {
 	if (work == NULL) {
@@ -731,6 +735,7 @@ int cxl_work_set_num_irqs(struct cxl_ioctl_start_work *work, __s16 irqs)
 	return 0;
 }
 
+inline
 int cxl_work_set_wed(struct cxl_ioctl_start_work *work, __u64 wed)
 {
 	if (work == NULL) {

--- a/libcxl.h
+++ b/libcxl.h
@@ -91,8 +91,7 @@ int cxl_afu_opened(struct cxl_afu_h *afu);
 /*
  * Attach AFU context to this process
  */
-struct cxl_ioctl_start_work *cxl_work_alloc();
-int cxl_work_attach(struct cxl_ioctl_start_work *work, struct cxl_afu_h *afu);
+struct cxl_ioctl_start_work *cxl_work_alloc(void);
 int cxl_work_free(struct cxl_ioctl_start_work *work);
 int cxl_work_get_amr(struct cxl_ioctl_start_work *work, __u64 *valp);
 int cxl_work_get_num_irqs(struct cxl_ioctl_start_work *work, __s16 *valp);
@@ -101,10 +100,13 @@ int cxl_work_set_amr(struct cxl_ioctl_start_work *work, __u64 amr);
 int cxl_work_set_num_irqs(struct cxl_ioctl_start_work *work, __s16 num_irqs);
 int cxl_work_set_wed(struct cxl_ioctl_start_work *work, __u64 wed);
 
-/* Deprecated interfaces */
+int cxl_afu_attach(struct cxl_afu_h *afu, __u64 wed);
+int cxl_afu_attach_work(struct cxl_afu_h *afu,
+			struct cxl_ioctl_start_work *work);
+
+/* Deprecated interface */
 int cxl_afu_attach_full(struct cxl_afu_h *afu, __u64 wed, __u16 num_interrupts,
 			__u64 amr);
-int cxl_afu_attach(struct cxl_afu_h *afu, __u64 wed);
 
 /*
  * Get AFU process element

--- a/libcxl.h
+++ b/libcxl.h
@@ -31,6 +31,7 @@
  */
 struct cxl_adapter_h;
 struct cxl_afu_h;
+struct cxl_ioctl_start_work;
 
 /*
  * Adapter Enumeration
@@ -90,6 +91,17 @@ int cxl_afu_opened(struct cxl_afu_h *afu);
 /*
  * Attach AFU context to this process
  */
+struct cxl_ioctl_start_work *cxl_work_alloc();
+int cxl_work_attach(struct cxl_ioctl_start_work *work, struct cxl_afu_h *afu);
+int cxl_work_free(struct cxl_ioctl_start_work *work);
+int cxl_work_get_amr(struct cxl_ioctl_start_work *work, __u64 *valp);
+int cxl_work_get_num_irqs(struct cxl_ioctl_start_work *work, __s16 *valp);
+int cxl_work_get_wed(struct cxl_ioctl_start_work *work, __u64 *valp);
+int cxl_work_set_amr(struct cxl_ioctl_start_work *work, __u64 amr);
+int cxl_work_set_num_irqs(struct cxl_ioctl_start_work *work, __s16 num_irqs);
+int cxl_work_set_wed(struct cxl_ioctl_start_work *work, __u64 wed);
+
+/* Deprecated interfaces */
 int cxl_afu_attach_full(struct cxl_afu_h *afu, __u64 wed, __u16 num_interrupts,
 			__u64 amr);
 int cxl_afu_attach(struct cxl_afu_h *afu, __u64 wed);

--- a/man3/cxl.3
+++ b/man3/cxl.3
@@ -1,6 +1,6 @@
 .\" Copyright 2015 IBM Corp.
 .\"
-.TH CXL 3 2015-02-27 "" "CXL Programmer's Manual"
+.TH CXL 3 2015-08-15 "LIBCXL 1.2" "CXL Programmer's Manual"
 .SH NAME
 cxl \- Coherent Accelerator Interface (CXL) library functions
 .SH SYNOPSIS
@@ -101,6 +101,15 @@ Function	Description
 _
 cxl_afu_attach_full	attach the calling process's memory to an open AFU
 cxl_afu_attach	attach the calling process's memory to an open AFU
+cxl_work_alloc	allocate and initialize a work structure
+cxl_work_attach	attach the calling process's memory to an open AFU
+cxl_work_free	free a work structure
+cxl_work_get_amr	get the value of the authority mask register
+cxl_work_get_num_irqs	get the number of interrupts requested
+cxl_work_get_wed	get the value of the work element descriptor
+cxl_work_set_amr	set the value of the authority mask register
+cxl_work_set_num_irqs	set the number of interrupts requested
+cxl_work_set_wed	set the value of the work element descriptor
 .TE
 .SS CXL Adapter Sysfs Helper functions
 .TS
@@ -206,8 +215,9 @@ cxl_errinfo_read	read and copy the contents of afu_err_info buffer into the prov
 .BR cxl_afu_open_h (3),
 .BR cxl_afu_opened (3),
 .BR cxl_afu_sysfs_pci (3),
-.BR cxl_errinfo_size (3),
 .BR cxl_errinfo_read (3),
+.BR cxl_errinfo_size (3),
+.BR cxl_event_pending (3),
 .BR cxl_for_each_adapter (3),
 .BR cxl_for_each_adapter_afu (3),
 .BR cxl_for_each_afu (3),
@@ -238,9 +248,18 @@ cxl_errinfo_read	read and copy the contents of afu_err_info buffer into the prov
 .BR cxl_mmio_unmap (3),
 .BR cxl_mmio_writ (3),2.3
 .BR cxl_mmio_write64 (3),
-.BR cxl_event_pending (3),
 .BR cxl_read_event (3),
 .BR cxl_read_expected_event (3),
 .BR cxl_set_irqs_max (3),
 .BR cxl_set_mode (3),
-.BR cxl_set_prefault_mode (3)
+.BR cxl_set_prefault_mode, (3)
+.BR cxl_work_alloc (3),
+.BR cxl_work_get_amr (3),
+.BR cxl_work_set_amr (3),
+.BR cxl_work_attach (3),
+.BR cxl_work_get_num_irqs (3),
+.BR cxl_work_set_num_irqs (3),
+.BR cxl_work_free (3),
+.BR cxl_work_get_wed (3),
+.BR cxl_work_set_wed (3)
+

--- a/man3/cxl.3
+++ b/man3/cxl.3
@@ -99,10 +99,10 @@ lb lb
 lb l.
 Function	Description
 _
-cxl_afu_attach_full	attach the calling process's memory to an open AFU
 cxl_afu_attach	attach the calling process's memory to an open AFU
+cxl_afu_attach_full	attach the calling process's memory to an open AFU (Deprecated Interface)
+cxl_afu_attach_work	attach the calling process's memory to an open AFU
 cxl_work_alloc	allocate and initialize a work structure
-cxl_work_attach	attach the calling process's memory to an open AFU
 cxl_work_free	free a work structure
 cxl_work_get_amr	get the value of the authority mask register
 cxl_work_get_num_irqs	get the number of interrupts requested
@@ -205,6 +205,7 @@ cxl_errinfo_read	read and copy the contents of afu_err_info buffer into the prov
 .BR cxl_adapter_next (3),
 .BR cxl_afu_attach (3),
 .BR cxl_afu_attach_full (3),
+.BR cxl_afu_attach_work (3),
 .BR cxl_afu_dev_name (3),
 .BR cxl_afu_fd (3),
 .BR cxl_afu_fd_to_h (3),
@@ -256,10 +257,8 @@ cxl_errinfo_read	read and copy the contents of afu_err_info buffer into the prov
 .BR cxl_work_alloc (3),
 .BR cxl_work_get_amr (3),
 .BR cxl_work_set_amr (3),
-.BR cxl_work_attach (3),
 .BR cxl_work_get_num_irqs (3),
 .BR cxl_work_set_num_irqs (3),
 .BR cxl_work_free (3),
 .BR cxl_work_get_wed (3),
 .BR cxl_work_set_wed (3)
-

--- a/man3/cxl_adapter_afu_next.3
+++ b/man3/cxl_adapter_afu_next.3
@@ -1,6 +1,6 @@
 .\" Copyright 2015 IBM Corp.
 .\"
-.TH CXL_ADAPTER_AFU_NEXT 3 2015-02-27 "" "CXL Programmer's Manual"
+.TH CXL_ADAPTER_AFU_NEXT 3 2015-08-15 "LIBCXL 1.2" "CXL Programmer's Manual"
 .SH NAME
 cxl_adapter_afu_next \- iterate to the next AFU of a CXL adapter
 .PP

--- a/man3/cxl_adapter_dev_name.3
+++ b/man3/cxl_adapter_dev_name.3
@@ -1,6 +1,6 @@
 .\" Copyright 2015 IBM Corp.
 .\"
-.TH CXL_ADAPTER_DEV_NAME 3 2015-02-27 "" "CXL Programmer's Manual"
+.TH CXL_ADAPTER_DEV_NAME 3 2015-08-15 "LIBCXL 1.2" "CXL Programmer's Manual"
 .SH NAME
 cxl_adapter_dev_name \- return the CXL adapter device name
 .SH SYNOPSIS

--- a/man3/cxl_adapter_free.3
+++ b/man3/cxl_adapter_free.3
@@ -1,6 +1,6 @@
 .\" Copyright 2015 IBM Corp.
 .\"
-.TH CXL_ADAPTER_FREE 3 2015-02-27 "" "CXL Programmer's Manual"
+.TH CXL_ADAPTER_FREE 3 2015-08-15 "LIBCXL 1.2" "CXL Programmer's Manual"
 .SH NAME
 cxl_adapter_free \- free the CXL adapter data structures
 .SH SYNOPSIS

--- a/man3/cxl_adapter_next.3
+++ b/man3/cxl_adapter_next.3
@@ -1,6 +1,6 @@
 .\" Copyright 2015 IBM Corp.
 .\"
-.TH CXL_ADAPTER_NEXT 3 2015-02-27 "" "CXL Programmer's Manual"
+.TH CXL_ADAPTER_NEXT 3 2015-08-15 "LIBCXL 1.2" "CXL Programmer's Manual"
 .SH NAME
 cxl_adapter_next \- iterate to the next CXL adapter
 .PP

--- a/man3/cxl_afu_attach.3
+++ b/man3/cxl_afu_attach.3
@@ -1,6 +1,6 @@
 .\" Copyright 2015 IBM Corp.
 .\"
-.TH CXL_AFU_ATTACH 3 2015-02-27 "" "CXL Programmer's Manual"
+.TH CXL_AFU_ATTACH 3 2015-08-15 "LIBCXL 1.2" "CXL Programmer's Manual"
 .SH NAME
 cxl_afu_attach \- attach the calling process's memory to an open AFU
 .SH SYNOPSIS

--- a/man3/cxl_afu_attach.3
+++ b/man3/cxl_afu_attach.3
@@ -50,6 +50,7 @@ Not enough interrupts available.
 .SH SEE ALSO
 .BR cxl (3),
 .BR cxl_afu_attach_full (3),
+.BR cxl_afu_attach_work (3),
 .BR cxl_afu_fd_to_h (3),
 .BR cxl_afu_free (3),
 .BR cxl_afu_open_dev (3),

--- a/man3/cxl_afu_attach_full.3
+++ b/man3/cxl_afu_attach_full.3
@@ -61,6 +61,7 @@ Not enough interrupts available.
 .SH SEE ALSO
 .BR cxl (3),
 .BR cxl_afu_attach (3),
+.BR cxl_afu_attach_work (3),
 .BR cxl_afu_fd_to_h (3),
 .BR cxl_afu_free (3),
 .BR cxl_afu_open_dev (3),

--- a/man3/cxl_afu_attach_full.3
+++ b/man3/cxl_afu_attach_full.3
@@ -1,6 +1,6 @@
 .\" Copyright 2015 IBM Corp.
 .\"
-.TH CXL_AFU_ATTACH_FULL 3 2015-02-27 "" "CXL Programmer's Manual"
+.TH CXL_AFU_ATTACH_FULL 3 2015-08-15 "LIBCXL 1.2" "CXL Programmer's Manual"
 .SH NAME
 cxl_afu_attach_full \- attach the calling process's memory to an open AFU
 .SH SYNOPSIS

--- a/man3/cxl_afu_attach_work.3
+++ b/man3/cxl_afu_attach_work.3
@@ -1,0 +1,87 @@
+.\" Copyright 2015 IBM Corp.
+.\"
+.TH CXL_AFU_ATTACH_WORK 3 2015-08-15 "LIBCXL 1.2" "CXL Programmer's Manual"
+.SH NAME
+cxl_afu_attach_work \- attach the calling process's memory to an open AFU
+.SH SYNOPSIS
+.B #include <libcxl.h>
+.PP
+.B "int cxl_afu_attach_work(struct cxl_afu_h"
+.BI * afu ", struct cxl_ioctl_work_attach *" work );
+.SH DESCRIPTION
+.BR cxl_afu_attach_work ()
+attaches a context of
+.I afu
+to the current process, specifying various parameters via the
+.I work
+structure, and starts the AFU context.
+.PP
+On success, all memory mapped into this process is accessible to the
+AFU context using the same effective addresses.
+No additional calls are required to map/unmap memory.
+The AFU memory context will be updated as userspace allocates and
+frees memory.
+.PP
+Three parameters can be set in the
+.I work
+structure:
+.PP
+.BR cxl_work_set_wed ()
+sets the work element descriptor, a 64-bit argument defined by the AFU.
+Typically this is an effective address pointing to an AFU specific
+structure describing what work to perform.
+.PP
+.BR cxl_work_set_num_irqs ()
+requests a number of userspace interrupts,
+in the range defined by
+.BR cxl_get_irqs_min ()
+and
+.BR cxl_get_irqs_max ().
+A negative value specifies that 
+.BR cxl_afu_attach_work ()
+should allocate the minimum number of interrupts required
+by an AFU context, returned by
+.BR cxl_get_irqs_min ().
+.PP
+.BR cxl_work_set_amr ()
+sets the authority mask register (same as the powerpc AMR).
+A null value indicates that the authority mask register
+should not be set.
+.SH RETURN VALUE
+On success, 0 is returned.
+On error, \-1 is returned and
+.I errno
+is set appropriately.
+.SH ERRORS
+.TP
+.B EINVAL
+Invalid argument value, or AFU not opened.
+.TP
+.B ENOMEM
+Not enough memory.
+.TP
+.B ENOSPC
+Not enough interrupts available.
+.SH SEE ALSO
+.BR cxl (),
+.BR cxl_afu_attach (),
+.BR cxl_afu_attach_full (),
+.BR cxl_afu_fd_to_h (),
+.BR cxl_afu_free (),
+.BR cxl_afu_open_dev (),
+.BR cxl_afu_opened (),
+.BR cxl_get_irqs_max (),
+.BR cxl_get_irqs_min (),
+.BR cxl_get_prefault_mode (),
+.BR cxl_mmio_map (),
+.BR cxl_set_irqs_max (),
+.BR cxl_set_mode (),
+.BR cxl_set_prefault_mode (),
+.BR cxl_work_alloc (),
+.BR cxl_work_free (),
+.BR cxl_work_get_amr (),
+.BR cxl_work_get_num_irqs (),
+.BR cxl_work_get_wed (),
+.BR cxl_work_set_amr (),
+.BR cxl_work_set_num_irqs (),
+.BR cxl_work_set_wed ()

--- a/man3/cxl_afu_dev_name.3
+++ b/man3/cxl_afu_dev_name.3
@@ -1,6 +1,6 @@
 .\" Copyright 2015 IBM Corp.
 .\"
-.TH CXL_AFU_DEV_NAME 3 2015-02-27 "" "CXL Programmer's Manual"
+.TH CXL_AFU_DEV_NAME 3 2015-08-15 "LIBCXL 1.2" "CXL Programmer's Manual"
 .SH NAME
 cxl_afu_dev_name \- return the AFU device name
 .SH SYNOPSIS

--- a/man3/cxl_afu_fd.3
+++ b/man3/cxl_afu_fd.3
@@ -1,6 +1,6 @@
 .\" Copyright 2015 IBM Corp.
 .\"
-.TH CXL_AFU_FD 3 2015-02-27 "" "CXL Programmer's Manual"
+.TH CXL_AFU_FD 3 2015-08-15 "LIBCXL 1.2" "CXL Programmer's Manual"
 .SH NAME
 cxl_afu_fd \- return the file descriptor of an AFU handle
 .SH SYNOPSIS

--- a/man3/cxl_afu_fd_to_h.3
+++ b/man3/cxl_afu_fd_to_h.3
@@ -52,6 +52,7 @@ AFU device in AFU directed mode, slave context.
 .SH SEE ALSO
 .BR cxl (3),
 .BR cxl_afu_attach (3),
+.BR cxl_afu_attach_work (3),
 .BR cxl_afu_attach_full (3),
 .BR cxl_afu_dev_name (3),
 .BR cxl_afu_fd (3),

--- a/man3/cxl_afu_fd_to_h.3
+++ b/man3/cxl_afu_fd_to_h.3
@@ -1,6 +1,6 @@
 .\" Copyright 2015 IBM Corp.
 .\"
-.TH CXL_AFU_FD_TO_H 3 2015-02-27 "" "CXL Programmer's Manual"
+.TH CXL_AFU_FD_TO_H 3 2015-08-15 "LIBCXL 1.2" "CXL Programmer's Manual"
 .SH NAME
 cxl_afu_fd_to_h \- create an AFU handle from the file descriptor of an already open AFU
 .SH SYNOPSIS

--- a/man3/cxl_afu_free.3
+++ b/man3/cxl_afu_free.3
@@ -1,6 +1,6 @@
 .\" Copyright 2015 IBM Corp.
 .\"
-.TH CXL_AFU_FREE 3 2015-02-27 "" "CXL Programmer's Manual"
+.TH CXL_AFU_FREE 3 2015-08-15 "LIBCXL 1.2" "CXL Programmer's Manual"
 .SH NAME
 cxl_afu_free \- free the data structures of an AFU handle
 .SH SYNOPSIS

--- a/man3/cxl_afu_free.3
+++ b/man3/cxl_afu_free.3
@@ -17,6 +17,7 @@ frees the data structures and memory buffers of
 .BR cxl_adapter_afu_next (3),
 .BR cxl_afu_attach (3),
 .BR cxl_afu_attach_full (3),
+.BR cxl_afu_attach_work (3),
 .BR cxl_afu_fd (3),
 .BR cxl_afu_fd_to_h (3),
 .BR cxl_afu_next (3),

--- a/man3/cxl_afu_get_process_element.3
+++ b/man3/cxl_afu_get_process_element.3
@@ -1,6 +1,6 @@
 .\" Copyright 2015 IBM Corp.
 .\"
-.TH CXL_AFU_GET_PROCESS_ELEMENT 3 2015-02-27 "" "CXL Manual"
+.TH CXL_AFU_GET_PROCESS_ELEMENT 3 2015-08-15 "LIBCXL 1.2" "CXL Manual"
 .SH NAME
 cxl_afu_get_process_element \- get the process element associated with an open AFU handle
 .SH SYNOPSIS

--- a/man3/cxl_afu_next.3
+++ b/man3/cxl_afu_next.3
@@ -1,6 +1,6 @@
 .\" Copyright 2015 IBM Corp.
 .\"
-.TH CXL_AFU_NEXT 3 2015-02-27 "" "CXL Programmer's Manual"
+.TH CXL_AFU_NEXT 3 2015-08-15 "LIBCXL 1.2" "CXL Programmer's Manual"
 .SH NAME
 cxl_afu_next \- iterate to the next AFU
 .PP

--- a/man3/cxl_afu_open_dev.3
+++ b/man3/cxl_afu_open_dev.3
@@ -53,6 +53,7 @@ AFU device in AFU directed mode, slave context.
 .BR cxl (3),
 .BR cxl_afu_attach (3),
 .BR cxl_afu_attach_full (3),
+.BR cxl_afu_attach_work (3),
 .BR cxl_afu_dev_name (3),
 .BR cxl_afu_fd (3),
 .BR cxl_afu_fd_to_h (3),

--- a/man3/cxl_afu_open_dev.3
+++ b/man3/cxl_afu_open_dev.3
@@ -1,6 +1,6 @@
 .\" Copyright 2015 IBM Corp.
 .\"
-.TH CXL_AFU_OPEN_DEV 3 2015-02-27 "" "CXL Programmer's Manual"
+.TH CXL_AFU_OPEN_DEV 3 2015-08-15 "LIBCXL 1.2" "CXL Programmer's Manual"
 .SH NAME
 cxl_afu_open_dev \- open an AFU by device name
 .SH SYNOPSIS

--- a/man3/cxl_afu_open_h.3
+++ b/man3/cxl_afu_open_h.3
@@ -1,6 +1,6 @@
 .\" Copyright 2015 IBM Corp.
 .\"
-.TH CXL_AFU_OPEN_H 3 2015-02-27 "" "CXL Programmer's Manual"
+.TH CXL_AFU_OPEN_H 3 2015-08-15 "LIBCXL 1.2" "CXL Programmer's Manual"
 .SH NAME
 cxl_afu_open_h \- open an AFU by AFU handle
 .SH SYNOPSIS

--- a/man3/cxl_afu_opened.3
+++ b/man3/cxl_afu_opened.3
@@ -1,6 +1,6 @@
 .\" Copyright 2015 IBM Corp.
 .\"
-.TH CXL_AFU_OPENED 3 2015-02-27 "" "CXL Programmer's Manual"
+.TH CXL_AFU_OPENED 3 2015-08-15 "LIBCXL 1.2" "CXL Programmer's Manual"
 .SH NAME
 cxl_afu_opened \- return whether an AFU handle is opened
 .SH SYNOPSIS

--- a/man3/cxl_afu_opened.3
+++ b/man3/cxl_afu_opened.3
@@ -26,6 +26,7 @@ Invalid argument value.
 .BR cxl (3),
 .BR cxl_afu_attach (3),
 .BR cxl_afu_attach_full (3),
+.BR cxl_afu_attach_work (3),
 .BR cxl_afu_dev_name (3),
 .BR cxl_afu_fd (3),
 .BR cxl_afu_fd_to_h (3),

--- a/man3/cxl_afu_sysfs_pci.3
+++ b/man3/cxl_afu_sysfs_pci.3
@@ -1,6 +1,6 @@
 .\" Copyright 2015 IBM Corp.
 .\"
-.TH CXL_AFU_SYSFS_PCI 3 2015-02-27 "" "CXL Programmer's Manual"
+.TH CXL_AFU_SYSFS_PCI 3 2015-08-15 "LIBCXL 1.2" "CXL Programmer's Manual"
 .SH NAME
 cxl_afu_sysfs_pci \- get the sysfs path to the PCI device corresponding with 
 an AFU

--- a/man3/cxl_errinfo_read.3
+++ b/man3/cxl_errinfo_read.3
@@ -1,6 +1,6 @@
 .\" Copyright 2015 IBM Corp.
 .\"
-.TH CXL_ERRINFO_READ 3 2015-02-27 "" "CXL Programmer's Manual"
+.TH CXL_ERRINFO_READ 3 2015-08-15 "LIBCXL 1.2" "CXL Programmer's Manual"
 .SH NAME
 cxl_errinfo_read \- Read and copy the contents of afu_err_info buffer
 .SH SYNOPSIS

--- a/man3/cxl_errinfo_read.3
+++ b/man3/cxl_errinfo_read.3
@@ -62,4 +62,4 @@ application specific and depends on the AFU being used.
 
 .SH SEE ALSO
 .BR cxl (3),
-.BR cxl_errinfo_size (3),
+.BR cxl_errinfo_size (3)

--- a/man3/cxl_errinfo_size.3
+++ b/man3/cxl_errinfo_size.3
@@ -63,4 +63,4 @@ application specific and depends on the AFU being used.
 
 .SH SEE ALSO
 .BR cxl (3),
-.BR cxl_errinfo_read (3),
+.BR cxl_errinfo_read (3)

--- a/man3/cxl_errinfo_size.3
+++ b/man3/cxl_errinfo_size.3
@@ -1,6 +1,6 @@
 .\" Copyright 2015 IBM Corp.
 .\"
-.TH CXL_ERRINFO_SIZE 3 2015-02-27 "" "CXL Programmer's Manual"
+.TH CXL_ERRINFO_SIZE 3 2015-08-15 "LIBCXL 1.2" "CXL Programmer's Manual"
 .SH NAME
 cxl_errinfo_size \- returns the size of afu_err_buff in bytes
 .SH SYNOPSIS

--- a/man3/cxl_event_pending.3
+++ b/man3/cxl_event_pending.3
@@ -1,6 +1,6 @@
 .\" Copyright 2015 IBM Corp.
 .\"
-.TH CXL_EVENT_PENDING 3 2015-02-27 "" "CXL Programmer's Manual"
+.TH CXL_EVENT_PENDING 3 2015-08-15 "LIBCXL 1.2" "CXL Programmer's Manual"
 .SH NAME
 cxl_event_pending \- return whether a CXL event is pending
 .SH SYNOPSIS

--- a/man3/cxl_fprint_event.3
+++ b/man3/cxl_fprint_event.3
@@ -1,6 +1,6 @@
 .\" Copyright 2015 IBM Corp.
 .\"
-.TH CXL_FPRINT_EVENT 3 2015-02-27 "" "CXL Programmer's Manual"
+.TH CXL_FPRINT_EVENT 3 2015-08-15 "LIBCXL 1.2" "CXL Programmer's Manual"
 .SH NAME
 cxl_fprint_event \- print out a description of a CXL event for debugging
 .SH SYNOPSIS

--- a/man3/cxl_fprint_unknown_event.3
+++ b/man3/cxl_fprint_unknown_event.3
@@ -1,6 +1,6 @@
 .\" Copyright 2015 IBM Corp.
 .\"
-.TH CXL_FPRINT_UNKNOWN_EVENT 3 2015-02-27 "" "CXL Manual"
+.TH CXL_FPRINT_UNKNOWN_EVENT 3 2015-08-15 "LIBCXL 1.2" "CXL Manual"
 .SH NAME
 cxl_fprint_unknown_event \- print out a hex dump of a raw CXL event for debugging
 .SH SYNOPSIS

--- a/man3/cxl_get_api_version.3
+++ b/man3/cxl_get_api_version.3
@@ -1,6 +1,6 @@
 .\" Copyright 2015 IBM Corp.
 .\"
-.TH CXL_GET_API_VERSION 3 2015-02-27 "" "CXL Programmer's Manual"
+.TH CXL_GET_API_VERSION 3 2015-08-15 "LIBCXL 1.2" "CXL Programmer's Manual"
 .SH NAME
 cxl_get_api_version \- get the version of the kernel CXL API
 .SH SYNOPSIS

--- a/man3/cxl_get_api_version_compatible.3
+++ b/man3/cxl_get_api_version_compatible.3
@@ -1,6 +1,6 @@
 .\" Copyright 2015 IBM Corp.
 .\"
-.TH CXL_GET_API_VERSION_COMPATIBLE 3 2015-02-27 "" "CXL Manual"
+.TH CXL_GET_API_VERSION_COMPATIBLE 3 2015-08-15 "LIBCXL 1.2" "CXL Manual"
 .SH NAME
 cxl_get_api_version_compatible \- get the lowest CXL API version compatible with the kernel
 .SH SYNOPSIS

--- a/man3/cxl_get_base_image.3
+++ b/man3/cxl_get_base_image.3
@@ -1,6 +1,6 @@
 .\" Copyright 2015 IBM Corp.
 .\"
-.TH CXL_GET_BASE_IMAGE 3 2015-02-27 "" "CXL Programmer's Manual"
+.TH CXL_GET_BASE_IMAGE 3 2015-08-15 "LIBCXL 1.2" "CXL Programmer's Manual"
 .SH NAME
 cxl_get_base_image \- get the revision level of the initial PSL image loaded  on the CXL device
 .SH SYNOPSIS

--- a/man3/cxl_get_caia_version.3
+++ b/man3/cxl_get_caia_version.3
@@ -1,6 +1,6 @@
 .\" Copyright 2015 IBM Corp.
 .\"
-.TH CXL_GET_CAIA_VERSION 3 2015-02-27 "" "CXL Programmer's Manual"
+.TH CXL_GET_CAIA_VERSION 3 2015-08-15 "LIBCXL 1.2" "CXL Programmer's Manual"
 .SH NAME
 cxl_get_caia_version \- get the CAIA version supported by a CXL adapter
 .SH SYNOPSIS

--- a/man3/cxl_get_cr_class.3
+++ b/man3/cxl_get_cr_class.3
@@ -1,6 +1,6 @@
 .\" Copyright 2015 IBM Corp.
 .\"
-.TH CXL_GET_CR_CLASS 3 2015-02-27 "" "CXL Programmer's Manual"
+.TH CXL_GET_CR_CLASS 3 2015-08-15 "LIBCXL 1.2" "CXL Programmer's Manual"
 .SH NAME
 cxl_get_cr_class \- get the class code out of an AFU configuration record
 .SH SYNOPSIS

--- a/man3/cxl_get_cr_device.3
+++ b/man3/cxl_get_cr_device.3
@@ -1,6 +1,6 @@
 .\" Copyright 2015 IBM Corp.
 .\"
-.TH CXL_GET_CR_DEVICE 3 2015-02-27 "" "CXL Programmer's Manual"
+.TH CXL_GET_CR_DEVICE 3 2015-08-15 "LIBCXL 1.2" "CXL Programmer's Manual"
 .SH NAME
 cxl_get_cr_device \- get the device ID out of an AFU configuration record
 .SH SYNOPSIS

--- a/man3/cxl_get_cr_vendor.3
+++ b/man3/cxl_get_cr_vendor.3
@@ -1,6 +1,6 @@
 .\" Copyright 2015 IBM Corp.
 .\"
-.TH CXL_GET_CR_VENDOR 3 2015-02-27 "" "CXL Programmer's Manual"
+.TH CXL_GET_CR_VENDOR 3 2015-08-15 "LIBCXL 1.2" "CXL Programmer's Manual"
 .SH NAME
 cxl_get_cr_vendor \- get the vendor ID out of an AFU configuration record
 .SH SYNOPSIS

--- a/man3/cxl_get_image_loaded.3
+++ b/man3/cxl_get_image_loaded.3
@@ -1,6 +1,6 @@
 .\" Copyright 2015 IBM Corp.
 .\"
-.TH CXL_GET_IMAGE_LOADED 3 2015-02-27 "" "CXL Programmer's Manual"
+.TH CXL_GET_IMAGE_LOADED 3 2015-08-15 "LIBCXL 1.2" "CXL Programmer's Manual"
 .SH NAME
 cxl_get_image_loaded \- returns which of the user and factory PSL images is currently loaded on the CXL device
 .SH SYNOPSIS

--- a/man3/cxl_get_irqs_max.3
+++ b/man3/cxl_get_irqs_max.3
@@ -1,6 +1,6 @@
 .\" Copyright 2015 IBM Corp.
 .\"
-.TH CXL_GET_IRQS_MAX 3 2015-02-27 "" "CXL Programmer's Manual"
+.TH CXL_GET_IRQS_MAX 3 2015-08-15 "LIBCXL 1.2" "CXL Programmer's Manual"
 .SH NAME
 cxl_get_irqs_max \- get the maximum number of AFU interrupts available to a context, if it was the only context running
 .SH SYNOPSIS
@@ -44,4 +44,6 @@ Insufficient memory.
 .BR cxl_get_mode (3),
 .BR cxl_get_modes_supported (3),
 .BR cxl_get_prefault_mode (3),
-.BR cxl_set_irqs_max (3)
+.BR cxl_set_irqs_max (3),
+.BR cxl_work_attach (3),
+.BR cxl_work_set_num_irqs (3)

--- a/man3/cxl_get_irqs_max.3
+++ b/man3/cxl_get_irqs_max.3
@@ -19,6 +19,8 @@ if it was the only context running.
 This is the maximum number of interrupts that may be requested
 when calling
 .BR cxl_afu_attach_full ()
+or
+.BR cxl_afu_attach_work ()
 for
 .IR afu .
 The default on probe is the maximum that hardware can support.
@@ -40,10 +42,10 @@ Insufficient memory.
 .BR cxl (3),
 .BR cxl_afu_attach (3),
 .BR cxl_afu_attach_full (3),
+.BR cxl_afu_attach_work (3),
 .BR cxl_get_irqs_min (3),
 .BR cxl_get_mode (3),
 .BR cxl_get_modes_supported (3),
 .BR cxl_get_prefault_mode (3),
 .BR cxl_set_irqs_max (3),
-.BR cxl_work_attach (3),
 .BR cxl_work_set_num_irqs (3)

--- a/man3/cxl_get_irqs_min.3
+++ b/man3/cxl_get_irqs_min.3
@@ -18,6 +18,8 @@ for each context of
 .PP
 This is the minimum number that must be requested when calling
 .BR cxl_afu_attach_full ()
+or
+.BR cxl_afu_attach_work ()
 for
 .IR afu .
 It is implicitly requested by
@@ -38,10 +40,10 @@ Insufficient memory.
 .BR cxl (3),
 .BR cxl_afu_attach (3),
 .BR cxl_afu_attach_full (3),
+.BR cxl_afu_attach_work (3),
 .BR cxl_get_irqs_max (3),
 .BR cxl_get_mode (3),
 .BR cxl_get_modes_supported (3),
 .BR cxl_get_prefault_mode (3),
 .BR cxl_set_irqs_max (3),
-.BR cxl_work_attach (3),
 .BR cxl_work_set_num_irqs (3)

--- a/man3/cxl_get_irqs_min.3
+++ b/man3/cxl_get_irqs_min.3
@@ -1,6 +1,6 @@
 .\" Copyright 2015 IBM Corp.
 .\"
-.TH CXL_GET_IRQS_MIN 3 2015-02-27 "" "CXL Programmer's Manual"
+.TH CXL_GET_IRQS_MIN 3 2015-08-15 "LIBCXL 1.2" "CXL Programmer's Manual"
 .SH NAME
 cxl_get_irqs_min \- get the minimum number of AFU interrupts required for each context
 .SH SYNOPSIS
@@ -42,4 +42,6 @@ Insufficient memory.
 .BR cxl_get_mode (3),
 .BR cxl_get_modes_supported (3),
 .BR cxl_get_prefault_mode (3),
-.BR cxl_set_irqs_max (3)
+.BR cxl_set_irqs_max (3),
+.BR cxl_work_attach (3),
+.BR cxl_work_set_num_irqs (3)

--- a/man3/cxl_get_mmio_size.3
+++ b/man3/cxl_get_mmio_size.3
@@ -1,6 +1,6 @@
 .\" Copyright 2015 IBM Corp.
 .\"
-.TH CXL_GET_MMIO_SIZE 3 2015-02-27 "" "CXL Programmer's Manual"
+.TH CXL_GET_MMIO_SIZE 3 2015-08-15 "LIBCXL 1.2" "CXL Programmer's Manual"
 .SH NAME
 cxl_get_mmio_size \- get the total size of the MMIO space of an AFU, including all per-process areas
 .PP

--- a/man3/cxl_get_mode.3
+++ b/man3/cxl_get_mode.3
@@ -1,6 +1,6 @@
 .\" Copyright 2015 IBM Corp.
 .\"
-.TH CXL_GET_MODE 3 2015-02-27 "" "CXL Programmer's Manual"
+.TH CXL_GET_MODE 3 2015-08-15 "LIBCXL 1.2" "CXL Programmer's Manual"
 .SH NAME
 cxl_get_mode \- get the current programming mode of an AFU
 .SH SYNOPSIS

--- a/man3/cxl_get_modes_supported.3
+++ b/man3/cxl_get_modes_supported.3
@@ -1,6 +1,6 @@
 .\" Copyright 2015 IBM Corp.
 .\"
-.TH CXL_GET_MODES_SUPPORTED 3 2015-02-27 "" "CXL Programmer's Manual"
+.TH CXL_GET_MODES_SUPPORTED 3 2015-08-15 "LIBCXL 1.2" "CXL Programmer's Manual"
 .SH NAME
 cxl_get_modes_supported \- get the programming modes supported by an AFU
 .SH SYNOPSIS

--- a/man3/cxl_get_pp_mmio_len.3
+++ b/man3/cxl_get_pp_mmio_len.3
@@ -1,6 +1,6 @@
 .\" Copyright 2015 IBM Corp.
 .\"
-.TH CXL_GET_PP_MMIO_LEN 3 2015-02-27 "" "CXL Programmer's Manual"
+.TH CXL_GET_PP_MMIO_LEN 3 2015-08-15 "LIBCXL 1.2" "CXL Programmer's Manual"
 .SH NAME
 cxl_get_pp_mmio_len \- get the per-process MMIO space length
 .SH SYNOPSIS

--- a/man3/cxl_get_pp_mmio_off.3
+++ b/man3/cxl_get_pp_mmio_off.3
@@ -1,6 +1,6 @@
 .\" Copyright 2015 IBM Corp.
 .\"
-.TH CXL_GET_PP_MMIO_OFF 3 2015-02-27 "" "CXL Programmer's Manual"
+.TH CXL_GET_PP_MMIO_OFF 3 2015-08-15 "LIBCXL 1.2" "CXL Programmer's Manual"
 .SH NAME
 cxl_get_pp_mmio_off \- get the per-process MMIO space offset
 .SH SYNOPSIS

--- a/man3/cxl_get_prefault_mode.3
+++ b/man3/cxl_get_prefault_mode.3
@@ -30,7 +30,10 @@ prefault what it points to.
 .TP
 .B CXL_PREFAULT_MODE_ALL
 Prefault all the segments mapped by the process calling
-.BR cxl_afu_attach ().
+.BR cxl_afu_attach (),
+.BR cxl_afu_attach_full ()
+or
+.BR cxl_afu_attach_work ().
 .SH RETURN VALUE
 On success, 0 is returned.
 On error, \-1 is returned and
@@ -48,6 +51,7 @@ Insufficient memory.
 .BR cxl_adapter_afu_next (3),
 .BR cxl_afu_attach (3),
 .BR cxl_afu_attach_full (3),
+.BR cxl_afu_attach_work (3),
 .BR cxl_afu_next (3),
 .BR cxl_get_api_version (3),
 .BR cxl_get_api_version_compatible (3),

--- a/man3/cxl_get_prefault_mode.3
+++ b/man3/cxl_get_prefault_mode.3
@@ -1,6 +1,6 @@
 .\" Copyright 2015 IBM Corp.
 .\"
-.TH CXL_GET_PREFAULT_MODE 3 2015-02-27 "" "CXL Programmer's Manual"
+.TH CXL_GET_PREFAULT_MODE 3 2015-08-15 "LIBCXL 1.2" "CXL Programmer's Manual"
 .SH NAME
 cxl_get_prefault_mode \- get the mode for prefaulting segments
 .SH SYNOPSIS

--- a/man3/cxl_get_psl_revision.3
+++ b/man3/cxl_get_psl_revision.3
@@ -1,6 +1,6 @@
 .\" Copyright 2015 IBM Corp.
 .\"
-.TH CXL_GET_PSL_REVISION 3 2015-02-27 "" "CXL Programmer's Manual"
+.TH CXL_GET_PSL_REVISION 3 2015-08-15 "LIBCXL 1.2" "CXL Programmer's Manual"
 .SH NAME
 cxl_get_psl_revision \- get the revision level of the current PSL image loaded on the CXL device
 .SH SYNOPSIS

--- a/man3/cxl_mmio_map.3
+++ b/man3/cxl_mmio_map.3
@@ -1,6 +1,6 @@
 .\" Copyright 2015 IBM Corp.
 .\"
-.TH CXL_MMIO_MAP 3 2015-02-27 "" "CXL Programmer's Manual"
+.TH CXL_MMIO_MAP 3 2015-08-15 "LIBCXL 1.2" "CXL Programmer's Manual"
 .SH NAME
 cxl_mmio_map \- map the per-process Problem State Area of an AFU to memory
 .SH SYNOPSIS

--- a/man3/cxl_mmio_map.3
+++ b/man3/cxl_mmio_map.3
@@ -61,6 +61,7 @@ AFU device in AFU directed mode, slave context.
 .BR cxl (3),
 .BR cxl_afu_attach (3),
 .BR cxl_afu_attach_full (3),
+.BR cxl_afu_attach_work (3),
 .BR cxl_get_mmio_size (3),
 .BR cxl_mmio_ptr (3),
 .BR cxl_mmio_read32 (3),

--- a/man3/cxl_mmio_ptr.3
+++ b/man3/cxl_mmio_ptr.3
@@ -1,6 +1,6 @@
 .\" Copyright 2015 IBM Corp.
 .\"
-.TH CXL_MMIO_PTR 3 2015-02-27 "" "CXL Programmer's Manual"
+.TH CXL_MMIO_PTR 3 2015-08-15 "LIBCXL 1.2" "CXL Programmer's Manual"
 .SH NAME
 cxl_mmio_ptr \- return the address of the mapped AFU Problem State Area
 .SH SYNOPSIS

--- a/man3/cxl_mmio_read32.3
+++ b/man3/cxl_mmio_read32.3
@@ -1,6 +1,6 @@
 .\" Copyright 2015 IBM Corp.
 .\"
-.TH CXL_MMIO_READ32 3 2015-02-27 "" "CXL Programmer's Manual"
+.TH CXL_MMIO_READ32 3 2015-08-15 "LIBCXL 1.2" "CXL Programmer's Manual"
 .SH NAME
 cxl_mmio_read32 \- read a 32-bit word from the mapped AFU Problem State Area
 .SH SYNOPSIS

--- a/man3/cxl_mmio_read64.3
+++ b/man3/cxl_mmio_read64.3
@@ -1,6 +1,6 @@
 .\" Copyright 2015 IBM Corp.
 .\"
-.TH CXL_MMIO_READ64 3 2015-02-27 "" "CXL Programmer's Manual"
+.TH CXL_MMIO_READ64 3 2015-08-15 "LIBCXL 1.2" "CXL Programmer's Manual"
 .SH NAME
 cxl_mmio_read64 \- read a 64-bit word from the mapped AFU Problem State Area
 .SH SYNOPSIS

--- a/man3/cxl_mmio_unmap.3
+++ b/man3/cxl_mmio_unmap.3
@@ -1,6 +1,6 @@
 .\" Copyright 2015 IBM Corp.
 .\"
-.TH CXL_MMIO_UNMAP 3 2015-02-27 "" "CXL Programmer's Manual"
+.TH CXL_MMIO_UNMAP 3 2015-08-15 "LIBCXL 1.2" "CXL Programmer's Manual"
 .SH NAME
 cxl_mmio_unmap \- unmap an AFU Problem State Area
 .SH SYNOPSIS

--- a/man3/cxl_mmio_write32.3
+++ b/man3/cxl_mmio_write32.3
@@ -1,6 +1,6 @@
 .\" Copyright 2015 IBM Corp.
 .\"
-.TH CXL_MMIO_WRITE32 3 2015-02-27 "" "CXL Programmer's Manual"
+.TH CXL_MMIO_WRITE32 3 2015-08-15 "LIBCXL 1.2" "CXL Programmer's Manual"
 .SH NAME
 cxl_mmio_write32 \- write a 32-bit word to the mapped AFU Problem State Area
 .SH SYNOPSIS

--- a/man3/cxl_mmio_write64.3
+++ b/man3/cxl_mmio_write64.3
@@ -1,6 +1,6 @@
 .\" Copyright 2015 IBM Corp.
 .\"
-.TH CXL_MMIO_WRITE64 3 2015-02-27 "" "CXL Programmer's Manual"
+.TH CXL_MMIO_WRITE64 3 2015-08-15 "LIBCXL 1.2" "CXL Programmer's Manual"
 .SH NAME
 cxl_mmio_write64 \- write a 64-bit word to the mapped AFU Problem State Area
 .SH SYNOPSIS

--- a/man3/cxl_read_event.3
+++ b/man3/cxl_read_event.3
@@ -1,6 +1,6 @@
 .\" Copyright 2015 IBM Corp.
 .\"
-.TH CXL_READ_EVENT 3 2015-02-27 "" "CXL Programmer's Manual"
+.TH CXL_READ_EVENT 3 2015-08-15 "LIBCXL 1.2" "CXL Programmer's Manual"
 .SH NAME
 cxl_read_event \- read one CXL event from an AFU
 .SH SYNOPSIS

--- a/man3/cxl_read_expected_event.3
+++ b/man3/cxl_read_expected_event.3
@@ -1,6 +1,6 @@
 .\" Copyright 2015 IBM Corp.
 .\"
-.TH CXL_READ_EXPECTED_EVENT 3 2015-02-27 "" "CXL Manual"
+.TH CXL_READ_EXPECTED_EVENT 3 2015-08-15 "LIBCXL 1.2" "CXL Manual"
 .SH NAME
 cxl_read_expected_event \- read one CXL event from an AFU, and treat it as a failure, if it did not match an expected event
 .SH SYNOPSIS

--- a/man3/cxl_set_irqs_max.3
+++ b/man3/cxl_set_irqs_max.3
@@ -1,6 +1,6 @@
 .\" Copyright 2015 IBM Corp.
 .\"
-.TH CXL_SET_IRQS_MAX 3 2015-02-27 "" "CXL Programmer's Manual"
+.TH CXL_SET_IRQS_MAX 3 2015-08-15 "LIBCXL 1.2" "CXL Programmer's Manual"
 .SH NAME
 cxl_set_irqs_max \- administratively restrict the maximum number of AFU interrupts
 .SH SYNOPSIS

--- a/man3/cxl_set_irqs_max.3
+++ b/man3/cxl_set_irqs_max.3
@@ -14,7 +14,9 @@ sets the maximum number of interrupts that can be
 requested for
 .IR afu ,
 when calling
-.BR cxl_afu_attach_full ().
+.BR cxl_afu_attach_full ()
+or
+.BR cxl_afu_attach_work ().
 .I value
 must be greater or equal to the value returned by
 .BR cxl_get_irqs_min ().
@@ -30,5 +32,6 @@ Invalid argument value.
 .SH SEE ALSO
 .BR cxl (3),
 .BR cxl_afu_attach_full (3),
+.BR cxl_afu_attach_work (3),
 .BR cxl_get_irqs_max (3),
 .BR cxl_get_irqs_min (3)

--- a/man3/cxl_set_mode.3
+++ b/man3/cxl_set_mode.3
@@ -39,6 +39,7 @@ Invalid argument value.
 .BR cxl_adapter_afu_next (3),
 .BR cxl_afu_attach (3),
 .BR cxl_afu_attach_full (3),
+.BR cxl_afu_attach_work (3),
 .BR cxl_afu_fd_to_h (3),
 .BR cxl_afu_next (3),
 .BR cxl_afu_open_dev (3),

--- a/man3/cxl_set_mode.3
+++ b/man3/cxl_set_mode.3
@@ -1,6 +1,6 @@
 .\" Copyright 2015 IBM Corp.
 .\"
-.TH CXL_SET_MODE 3 2015-02-27 "" "CXL Programmer's Manual"
+.TH CXL_SET_MODE 3 2015-08-15 "LIBCXL 1.2" "CXL Programmer's Manual"
 .SH NAME
 cxl_set_mode \- set the programming mode of an AFU
 .SH SYNOPSIS

--- a/man3/cxl_set_prefault_mode.3
+++ b/man3/cxl_set_prefault_mode.3
@@ -1,6 +1,6 @@
 .\" Copyright 2015 IBM Corp.
 .\"
-.TH CXL_SET_PREFAULT_MODE 3 2015-02-27 "" "CXL Programmer's Manual"
+.TH CXL_SET_PREFAULT_MODE 3 2015-08-15 "LIBCXL 1.2" "CXL Programmer's Manual"
 .SH NAME
 cxl_set_prefault_mode \- set the mode for prefaulting segments
 .SH SYNOPSIS

--- a/man3/cxl_set_prefault_mode.3
+++ b/man3/cxl_set_prefault_mode.3
@@ -16,7 +16,10 @@ to
 .IR value .
 The current mode will be used for prefaulting in segments
 into the segment table when performing
-.BR cxl_afu_attach ().
+.BR cxl_afu_attach (),
+.BR cxl_afu_attach_full ()
+or
+.BR cxl_afu_attach_work ().
 Mode must be one of the
 .B "enum cxl_prefault_mode"
 values:
@@ -45,5 +48,6 @@ Invalid argument value.
 .BR cxl_adapter_afu_next (3),
 .BR cxl_afu_attach (3),
 .BR cxl_afu_attach_full (3),
+.BR cxl_afu_attach_work (3),
 .BR cxl_afu_next (3),
 .BR cxl_get_prefault_mode (3)

--- a/man3/cxl_work_alloc.3
+++ b/man3/cxl_work_alloc.3
@@ -1,0 +1,34 @@
+.\" Copyright 2015 IBM Corp.
+.\"
+.TH CXL_WORK_ALLOC 3 2015-08-15 "LIBCXL 1.2" "CXL Programmer's Manual"
+.SH NAME
+cxl_work_alloc \- allocate and initialize a work structure
+.SH SYNOPSIS
+.B #include <libcxl.h>
+.PP
+.B "struct cxl_ioctl_start_work *cxl_work_alloc();"
+.SH DESCRIPTION
+.BR cxl_work_alloc ()
+allocates, initializes, and returns a pointer to a work
+structure, that can be populated and passed to
+.BR cxl_afu_attach_work ().
+.SH RETURN VALUE
+On success, a pointer to the allocated
+structure is returned.
+On error, NULL is returned and
+.I errno
+is set appropriately.
+.SH ERRORS
+.TP
+.B ENOMEM
+Not enough memory.
+.SH SEE ALSO
+.BR cxl (3),
+.BR cxl_afu_attach_work (3),
+.BR cxl_work_free (3),
+.BR cxl_work_get_amr (3),
+.BR cxl_work_get_num_irqs (3),
+.BR cxl_work_get_wed (3),
+.BR cxl_work_set_amr (3),
+.BR cxl_work_set_num_irqs (3),
+.BR cxl_work_set_wed (3)

--- a/man3/cxl_work_free.3
+++ b/man3/cxl_work_free.3
@@ -1,0 +1,35 @@
+.\" Copyright 2015 IBM Corp.
+.\"
+.TH CXL_WORK_FREE 3 2015-08-15 "LIBCXL 1.2" "CXL Programmer's Manual"
+.SH NAME
+cxl_work_get_free \- free a work structure
+.SH SYNOPSIS
+.B #include <libcxl.h>
+.PP
+.B "int cxl_work_free(struct cxl_ioctl_start_work"
+.BI * work );
+.SH DESCRIPTION
+.BR cxl_work_free ()
+frees the
+.I work
+structure allocated by
+.BR cxl_work_alloc ().
+.SH RETURN VALUE
+On success, 0 is returned.
+On error, \-1 is returned and
+.I errno
+is set appropriately.
+.SH ERRORS
+.TP
+.B EINVAL
+Invalid argument value.
+.SH SEE ALSO
+.BR cxl (3),
+.BR cxl_afu_attach_work (3),
+.BR cxl_work_alloc (3),
+.BR cxl_work_get_amr (3),
+.BR cxl_work_get_num_irqs (3),
+.BR cxl_work_get_wed (3),
+.BR cxl_work_set_amr (3),
+.BR cxl_work_set_num_irqs (3),
+.BR cxl_work_set_wed (3)

--- a/man3/cxl_work_get_amr.3
+++ b/man3/cxl_work_get_amr.3
@@ -1,0 +1,35 @@
+.\" Copyright 2015 IBM Corp.
+.\"
+.TH CXL_WORK_GET_AMR 3 2015-08-15 "LIBCXL 1.2" "CXL Programmer's Manual"
+.SH NAME
+cxl_work_get_amr \- get the value of the authority mask register
+.SH SYNOPSIS
+.B #include <libcxl.h>
+.PP
+.B "int cxl_work_get_amr(struct cxl_ioctl_start_work"
+.BI * work ", __u64 *" valp );
+.SH DESCRIPTION
+.BR cxl_work_get_amr ()
+copies the value of the authority mask register from the struct
+.I work
+to the unsigned word pointed to by
+.IR valp .
+.SH RETURN VALUE
+On success, 0 is returned.
+On error, \-1 is returned and
+.I errno
+is set appropriately.
+.SH ERRORS
+.TP
+.B EINVAL
+Invalid argument value.
+.SH SEE ALSO
+.BR cxl (3),
+.BR cxl_afu_attach_work (3),
+.BR cxl_work_alloc (3),
+.BR cxl_work_free (3),
+.BR cxl_work_get_num_irqs (3),
+.BR cxl_work_get_wed (3),
+.BR cxl_work_set_amr (3),
+.BR cxl_work_set_num_irqs (3),
+.BR cxl_work_set_wed (3)

--- a/man3/cxl_work_get_num_irqs.3
+++ b/man3/cxl_work_get_num_irqs.3
@@ -1,0 +1,35 @@
+.\" Copyright 2015 IBM Corp.
+.\"
+.TH CXL_WORK_GET_NUM_IRQS 3 2015-08-15 "LIBCXL 1.2" "CXL Programmer's Manual"
+.SH NAME
+cxl_work_get_num_irqs \- get the number of interrupts requested
+.SH SYNOPSIS
+.B #include <libcxl.h>
+.PP
+.B "int cxl_work_get_num_irqs(struct cxl_ioctl_start_work"
+.BI * work ", __s16 *" valp );
+.SH DESCRIPTION
+.BR cxl_work_get_num_irqs ()
+copies the requested number of interrupts from
+.I work
+to the short integer pointed to by
+.IR valp .
+.SH RETURN VALUE
+On success, 0 is returned.
+On error, \-1 is returned and
+.I errno
+is set appropriately.
+.SH ERRORS
+.TP
+.B EINVAL
+Invalid argument value.
+.SH SEE ALSO
+.BR cxl (3),
+.BR cxl_afu_attach_work (3),
+.BR cxl_work_alloc (3),
+.BR cxl_work_free (3),
+.BR cxl_work_get_amr (3),
+.BR cxl_work_get_wed (3),
+.BR cxl_work_set_amr (3),
+.BR cxl_work_set_num_irqs (3),
+.BR cxl_work_set_wed (3)

--- a/man3/cxl_work_get_wed.3
+++ b/man3/cxl_work_get_wed.3
@@ -1,0 +1,35 @@
+.\" Copyright 2015 IBM Corp.
+.\"
+.TH CXL_WORK_GET_WED 3 2015-08-15 "LIBCXL 1.2" "CXL Programmer's Manual"
+.SH NAME
+cxl_work_get_wed \- get the value of the work element descriptor
+.SH SYNOPSIS
+.B #include <libcxl.h>
+.PP
+.B "int cxl_work_get_wed(struct cxl_ioctl_start_work"
+.BI * work ", __u64 *" valp );
+.SH DESCRIPTION
+.BR cxl_work_get_wed ()
+copies the value of the work element descriptor from the struct
+.I work
+to the unsigned word pointed to by
+.IR valp .
+.SH RETURN VALUE
+On success, 0 is returned.
+On error, \-1 is returned and
+.I errno
+is set appropriately.
+.SH ERRORS
+.TP
+.B EINVAL
+Invalid argument value.
+.SH SEE ALSO
+.BR cxl (3),
+.BR cxl_afu_attach_work (3),
+.BR cxl_work_alloc (3),
+.BR cxl_work_free (3),
+.BR cxl_work_get_amr (3),
+.BR cxl_work_get_num_irqs (3),
+.BR cxl_work_set_amr (3),
+.BR cxl_work_set_num_irqs (3),
+.BR cxl_work_set_wed (3)

--- a/man3/cxl_work_set_amr.3
+++ b/man3/cxl_work_set_amr.3
@@ -1,0 +1,38 @@
+.\" Copyright 2015 IBM Corp.
+.\"
+.TH CXL_WORK_SET_AMR 3 2015-08-15 "LIBCXL 1.2" "CXL Programmer's Manual"
+.SH NAME
+cxl_work_set_amr \- set the value of the authority mask register
+.SH SYNOPSIS
+.B #include <libcxl.h>
+.PP
+.B "int cxl_work_set_amr(struct cxl_ioctl_start_work"
+.BI * work ", __u64 " amr );
+.SH DESCRIPTION
+.BR cxl_work_set_amr ()
+sets the value of the authority mask register
+.I amr
+into the struct
+.IR work .
+A null value indicates that the authority mask register
+should not be set by
+.BR cxl_afu_attach_work ().
+.SH RETURN VALUE
+On success, 0 is returned.
+On error, \-1 is returned and
+.I errno
+is set appropriately.
+.SH ERRORS
+.TP
+.B EINVAL
+Invalid argument value.
+.SH SEE ALSO
+.BR cxl (3),
+.BR cxl_afu_attach_work (3),
+.BR cxl_work_alloc (3),
+.BR cxl_work_free (3),
+.BR cxl_work_get_amr (3),
+.BR cxl_work_get_num_irqs (3),
+.BR cxl_work_get_wed (3),
+.BR cxl_work_set_num_irqs (3),
+.BR cxl_work_set_wed (3)

--- a/man3/cxl_work_set_num_irqs.3
+++ b/man3/cxl_work_set_num_irqs.3
@@ -1,0 +1,41 @@
+.\" Copyright 2015 IBM Corp.
+.\"
+.TH CXL_WORK_SET_NUM_IRQS 3 2015-08-15 "LIBCXL 1.2" "CXL Programmer's Manual"
+.SH NAME
+cxl_work_set_num_irqs \- set the number of interrupts requested
+.SH SYNOPSIS
+.B #include <libcxl.h>
+.PP
+.B "int cxl_work_set_num_irqs(struct cxl_ioctl_start_work"
+.BI * work ", __s16 " num_irqs );
+.SH DESCRIPTION
+.BR cxl_work_set_num_irqs ()
+sets the number of interrupts requested
+.I num_irqs
+into the struct
+.IR work .
+If the value is negative, then
+.BR cxl_afu_attach_work (),
+will allocate the minimum number of interrupts required
+by an AFU context, returned by
+.BR cxl_get_irqs_min ().
+.SH RETURN VALUE
+On success, 0 is returned.
+On error, \-1 is returned and
+.I errno
+is set appropriately.
+.SH ERRORS
+.TP
+.B EINVAL
+Invalid argument value.
+.SH SEE ALSO
+.BR cxl (3),
+.BR cxl_afu_attach_work (3),
+.BR cxl_get_irqs_min (3),
+.BR cxl_work_alloc (3),
+.BR cxl_work_free (3),
+.BR cxl_work_get_amr (3),
+.BR cxl_work_get_num_irqs (3),
+.BR cxl_work_get_wed (3),
+.BR cxl_work_set_amr (3),
+.BR cxl_work_set_wed (3)

--- a/man3/cxl_work_set_wed.3
+++ b/man3/cxl_work_set_wed.3
@@ -1,0 +1,40 @@
+.\" Copyright 2015 IBM Corp.
+.\"
+.TH CXL_WORK_SET_WED 3 2015-08-15 "LIBCXL 1.2" "CXL Programmer's Manual"
+.SH NAME
+cxl_work_set_wed \- set the value of the work element descriptor
+.SH SYNOPSIS
+.B #include <libcxl.h>
+.PP
+.B "int cxl_work_set_wed(struct cxl_ioctl_start_work"
+.BI * work ", __u64 " wed );
+.SH DESCRIPTION
+.BR cxl_work_set_wed ()
+sets the value of the work element descriptor
+.I wed
+into the struct
+.IR work .
+The work element descriptor
+.wed
+is a 64-bit argument defined by the AFU.
+Typically this is an effective address pointing to an AFU specific
+structure describing what work to perform.
+.SH RETURN VALUE
+On success, 0 is returned.
+On error, \-1 is returned and
+.I errno
+is set appropriately.
+.SH ERRORS
+.TP
+.B EINVAL
+Invalid argument value.
+.SH SEE ALSO
+.BR cxl (3),
+.BR cxl_afu_attach_work (3),
+.BR cxl_work_alloc (3),
+.BR cxl_work_free (3),
+.BR cxl_work_get_amr (3),
+.BR cxl_work_get_num_irqs (3),
+.BR cxl_work_get_wed (3),
+.BR cxl_work_set_amr (3),
+.BR cxl_work_set_num_irqs (3)

--- a/man3/man2txt
+++ b/man3/man2txt
@@ -3,4 +3,4 @@
 # man2txt - format a man page into plain text
 
 tbl | groff -man -I.. -Tascii |
-sed -e 's/\(.\)\o010\1/\1/g' -e 's/_\o010//g' # a 'colcrt -' that works !
+sed -e 's/\(.\)\o010\1/\1/g' -e 's/_\o010//g' -e 's/\o033\[[0-9][0-9]*m//g'

--- a/symver.map
+++ b/symver.map
@@ -71,3 +71,16 @@ LIBCXL_1.1 {
 		cxl_get_cr_device;
 		cxl_get_cr_vendor;
 } LIBCXL_1;
+
+LIBCXL_1.2 {
+	global:
+		cxl_work_alloc;
+		cxl_work_attach;
+		cxl_work_free;
+		cxl_work_get_amr;
+		cxl_work_get_num_irqs;
+		cxl_work_get_wed;
+		cxl_work_set_amr;
+		cxl_work_set_num_irqs;
+		cxl_work_set_wed;
+} LIBCXL_1.1;

--- a/symver.map
+++ b/symver.map
@@ -74,8 +74,8 @@ LIBCXL_1.1 {
 
 LIBCXL_1.2 {
 	global:
+		cxl_afu_attach_work;
 		cxl_work_alloc;
-		cxl_work_attach;
 		cxl_work_free;
 		cxl_work_get_amr;
 		cxl_work_get_num_irqs;


### PR DESCRIPTION
- Use an object oriented interface to struct cxl_ioctl_start_work:
  cxl_work_alloc, cxl_work_attach, cxl_work_free,
  cxl_work_get_amr, cxl_work_get_num_irqs, cxl_work_get_wed,
  cxl_work_set_amr, cxl_work_set_num_irqs, cxl_work_set_wed.
- Only set the AMR flag if the passed in AMR value is non-zero.
- Change the num_irqs to be signed and use negative values to
  indicate that it should be set automatically.

Signed-off-by: Philippe Bergheaud felix@linux.vnet.ibm.com
