### PR TITLE
New API function cxl_get_psl_timebase_synced.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ OBJS = libcxl.o libcxl_sysfs.o
 CFLAGS += -I include
 
 # change VERS_LIB if new git tag
-VERS_LIB = 1.3
+VERS_LIB = 1.4
 LIBNAME   = libcxl.so.$(VERS_LIB)
 # change VERS_SONAME only if library breaks backward compatibility.
 # refer to file symver.map

--- a/libcxl.h
+++ b/libcxl.h
@@ -176,6 +176,7 @@ int cxl_get_caia_version(struct cxl_adapter_h *adapter, long *majorp,
 			 long *minorp);
 int cxl_get_image_loaded(struct cxl_adapter_h *adapter, enum cxl_image *valp);
 int cxl_get_psl_revision(struct cxl_adapter_h *adapter, long *valp);
+int cxl_get_psl_timebase_synced(struct cxl_adapter_h *adapter, long *valp);
 
 /*
  * Events

--- a/libcxl_sysfs.c
+++ b/libcxl_sysfs.c
@@ -53,6 +53,7 @@ enum cxl_sysfs_attr {
 	CAIA_VERSION,
 	IMAGE_LOADED,
 	PSL_REVISION,
+	PSL_TIMEBASE_SYNCED,
 };
 
 struct cxl_sysfs_entry {
@@ -89,9 +90,10 @@ static struct cxl_sysfs_entry sysfs_entry[] = {
  { "caia_version", scan_caia_version, 2 },	/* CAIA_VERSION */
  { "image_loaded", scan_image, 1 },		/* IMAGE_LOADED */
  { "psl_revision", scan_int, 1 },		/* PSL_REVISION */
+ { "psl_timebase_synced", scan_int, 1 },	/* PSL_TIMEBASE_SYNCED */
 };
 
-#define LAST_ATTR PSL_REVISION
+#define LAST_ATTR PSL_TIMEBASE_SYNCED
 #define OUT_OF_RANGE(attr) ((attr) < 0 || (attr) > LAST_ATTR)
 
 static int scan_int(char *attr_str, long *majorp, long *minorp)
@@ -424,6 +426,11 @@ int cxl_get_image_loaded(struct cxl_adapter_h *adapter, enum cxl_image *valp)
 int cxl_get_psl_revision(struct cxl_adapter_h *adapter, long *valp)
 {
 	return read_sysfs_adapter(adapter, PSL_REVISION, valp, NULL);
+}
+
+int cxl_get_psl_timebase_synced(struct cxl_adapter_h *adapter, long *valp)
+{
+	return read_sysfs_adapter(adapter, PSL_TIMEBASE_SYNCED, valp, NULL);
 }
 
 static int write_sysfs_str(char *path, enum cxl_sysfs_attr attr, char *str)

--- a/man3/cxl.3
+++ b/man3/cxl.3
@@ -1,6 +1,6 @@
 .\" Copyright 2015 IBM Corp.
 .\"
-.TH CXL 3 2015-08-15 "LIBCXL 1.2" "CXL Programmer's Manual"
+.TH CXL 3 2016-05-25 "LIBCXL 1.4" "CXL Programmer's Manual"
 .SH NAME
 cxl \- Coherent Accelerator Interface (CXL) library functions
 .SH SYNOPSIS
@@ -241,6 +241,7 @@ cxl_errinfo_read	read and copy the contents of afu_err_info buffer into the prov
 .BR cxl_get_pp_mmio_off (3),
 .BR cxl_get_prefault_mode (3),
 .BR cxl_get_psl_revision (3),
+.BR cxl_get_psl_timebase_synced (3),
 .BR cxl_mmio_install_sigbus_handler (3),
 .BR cxl_mmio_map (3),
 .BR cxl_mmio_ptr (3),

--- a/man3/cxl_adapter_afu_next.3
+++ b/man3/cxl_adapter_afu_next.3
@@ -1,6 +1,6 @@
 .\" Copyright 2015 IBM Corp.
 .\"
-.TH CXL_ADAPTER_AFU_NEXT 3 2015-08-15 "LIBCXL 1.2" "CXL Programmer's Manual"
+.TH CXL_ADAPTER_AFU_NEXT 3 2016-05-25 "LIBCXL 1.4" "CXL Programmer's Manual"
 .SH NAME
 cxl_adapter_afu_next \- iterate to the next AFU of a CXL adapter
 .PP

--- a/man3/cxl_adapter_dev_name.3
+++ b/man3/cxl_adapter_dev_name.3
@@ -1,6 +1,6 @@
 .\" Copyright 2015 IBM Corp.
 .\"
-.TH CXL_ADAPTER_DEV_NAME 3 2015-08-15 "LIBCXL 1.2" "CXL Programmer's Manual"
+.TH CXL_ADAPTER_DEV_NAME 3 2016-05-25 "LIBCXL 1.4" "CXL Programmer's Manual"
 .SH NAME
 cxl_adapter_dev_name \- return the CXL adapter device name
 .SH SYNOPSIS

--- a/man3/cxl_adapter_free.3
+++ b/man3/cxl_adapter_free.3
@@ -1,6 +1,6 @@
 .\" Copyright 2015 IBM Corp.
 .\"
-.TH CXL_ADAPTER_FREE 3 2015-08-15 "LIBCXL 1.2" "CXL Programmer's Manual"
+.TH CXL_ADAPTER_FREE 3 2016-05-25 "LIBCXL 1.4" "CXL Programmer's Manual"
 .SH NAME
 cxl_adapter_free \- free the CXL adapter data structures
 .SH SYNOPSIS

--- a/man3/cxl_adapter_next.3
+++ b/man3/cxl_adapter_next.3
@@ -1,6 +1,6 @@
 .\" Copyright 2015 IBM Corp.
 .\"
-.TH CXL_ADAPTER_NEXT 3 2015-08-15 "LIBCXL 1.2" "CXL Programmer's Manual"
+.TH CXL_ADAPTER_NEXT 3 2016-05-25 "LIBCXL 1.4" "CXL Programmer's Manual"
 .SH NAME
 cxl_adapter_next \- iterate to the next CXL adapter
 .PP
@@ -59,4 +59,5 @@ CXL adapters:
 .BR cxl_get_base_image (3),
 .BR cxl_get_caia_version (3),
 .BR cxl_get_image_loaded (3),
-.BR cxl_get_psl_revision (3)
+.BR cxl_get_psl_revision (3),
+.BR cxl_get_psl_timebase_synced (3)

--- a/man3/cxl_afu_attach.3
+++ b/man3/cxl_afu_attach.3
@@ -1,6 +1,6 @@
 .\" Copyright 2015 IBM Corp.
 .\"
-.TH CXL_AFU_ATTACH 3 2015-08-15 "LIBCXL 1.2" "CXL Programmer's Manual"
+.TH CXL_AFU_ATTACH 3 2016-05-25 "LIBCXL 1.4" "CXL Programmer's Manual"
 .SH NAME
 cxl_afu_attach \- attach the calling process's memory to an open AFU
 .SH SYNOPSIS

--- a/man3/cxl_afu_attach_full.3
+++ b/man3/cxl_afu_attach_full.3
@@ -1,6 +1,6 @@
 .\" Copyright 2015 IBM Corp.
 .\"
-.TH CXL_AFU_ATTACH_FULL 3 2015-08-15 "LIBCXL 1.2" "CXL Programmer's Manual"
+.TH CXL_AFU_ATTACH_FULL 3 2016-05-25 "LIBCXL 1.4" "CXL Programmer's Manual"
 .SH NAME
 cxl_afu_attach_full \- attach the calling process's memory to an open AFU
 .SH SYNOPSIS

--- a/man3/cxl_afu_attach_work.3
+++ b/man3/cxl_afu_attach_work.3
@@ -1,6 +1,6 @@
 .\" Copyright 2015 IBM Corp.
 .\"
-.TH CXL_AFU_ATTACH_WORK 3 2015-08-15 "LIBCXL 1.2" "CXL Programmer's Manual"
+.TH CXL_AFU_ATTACH_WORK 3 2016-05-25 "LIBCXL 1.4" "CXL Programmer's Manual"
 .SH NAME
 cxl_afu_attach_work \- attach the calling process's memory to an open AFU
 .SH SYNOPSIS

--- a/man3/cxl_afu_dev_name.3
+++ b/man3/cxl_afu_dev_name.3
@@ -1,6 +1,6 @@
 .\" Copyright 2015 IBM Corp.
 .\"
-.TH CXL_AFU_DEV_NAME 3 2015-08-15 "LIBCXL 1.2" "CXL Programmer's Manual"
+.TH CXL_AFU_DEV_NAME 3 2016-05-25 "LIBCXL 1.4" "CXL Programmer's Manual"
 .SH NAME
 cxl_afu_dev_name \- return the AFU device name
 .SH SYNOPSIS

--- a/man3/cxl_afu_fd.3
+++ b/man3/cxl_afu_fd.3
@@ -1,6 +1,6 @@
 .\" Copyright 2015 IBM Corp.
 .\"
-.TH CXL_AFU_FD 3 2015-08-15 "LIBCXL 1.2" "CXL Programmer's Manual"
+.TH CXL_AFU_FD 3 2016-05-25 "LIBCXL 1.4" "CXL Programmer's Manual"
 .SH NAME
 cxl_afu_fd \- return the file descriptor of an AFU handle
 .SH SYNOPSIS

--- a/man3/cxl_afu_fd_to_h.3
+++ b/man3/cxl_afu_fd_to_h.3
@@ -1,6 +1,6 @@
 .\" Copyright 2015 IBM Corp.
 .\"
-.TH CXL_AFU_FD_TO_H 3 2015-08-15 "LIBCXL 1.2" "CXL Programmer's Manual"
+.TH CXL_AFU_FD_TO_H 3 2016-05-25 "LIBCXL 1.4" "CXL Programmer's Manual"
 .SH NAME
 cxl_afu_fd_to_h \- create an AFU handle from the file descriptor of an already open AFU
 .SH SYNOPSIS

--- a/man3/cxl_afu_free.3
+++ b/man3/cxl_afu_free.3
@@ -1,6 +1,6 @@
 .\" Copyright 2015 IBM Corp.
 .\"
-.TH CXL_AFU_FREE 3 2015-08-15 "LIBCXL 1.2" "CXL Programmer's Manual"
+.TH CXL_AFU_FREE 3 2016-05-25 "LIBCXL 1.4" "CXL Programmer's Manual"
 .SH NAME
 cxl_afu_free \- free the data structures of an AFU handle
 .SH SYNOPSIS

--- a/man3/cxl_afu_get_process_element.3
+++ b/man3/cxl_afu_get_process_element.3
@@ -1,6 +1,6 @@
 .\" Copyright 2015 IBM Corp.
 .\"
-.TH CXL_AFU_GET_PROCESS_ELEMENT 3 2015-08-15 "LIBCXL 1.2" "CXL Manual"
+.TH CXL_AFU_GET_PROCESS_ELEMENT 3 2016-05-25 "LIBCXL 1.4" "CXL Manual"
 .SH NAME
 cxl_afu_get_process_element \- get the process element associated with an open AFU handle
 .SH SYNOPSIS

--- a/man3/cxl_afu_next.3
+++ b/man3/cxl_afu_next.3
@@ -1,6 +1,6 @@
 .\" Copyright 2015 IBM Corp.
 .\"
-.TH CXL_AFU_NEXT 3 2015-08-15 "LIBCXL 1.2" "CXL Programmer's Manual"
+.TH CXL_AFU_NEXT 3 2016-05-25 "LIBCXL 1.4" "CXL Programmer's Manual"
 .SH NAME
 cxl_afu_next \- iterate to the next AFU
 .PP

--- a/man3/cxl_afu_open_dev.3
+++ b/man3/cxl_afu_open_dev.3
@@ -1,6 +1,6 @@
 .\" Copyright 2015 IBM Corp.
 .\"
-.TH CXL_AFU_OPEN_DEV 3 2015-08-15 "LIBCXL 1.2" "CXL Programmer's Manual"
+.TH CXL_AFU_OPEN_DEV 3 2016-05-25 "LIBCXL 1.4" "CXL Programmer's Manual"
 .SH NAME
 cxl_afu_open_dev \- open an AFU by device name
 .SH SYNOPSIS

--- a/man3/cxl_afu_open_h.3
+++ b/man3/cxl_afu_open_h.3
@@ -1,6 +1,6 @@
 .\" Copyright 2015 IBM Corp.
 .\"
-.TH CXL_AFU_OPEN_H 3 2015-08-15 "LIBCXL 1.2" "CXL Programmer's Manual"
+.TH CXL_AFU_OPEN_H 3 2016-05-25 "LIBCXL 1.4" "CXL Programmer's Manual"
 .SH NAME
 cxl_afu_open_h \- open an AFU by AFU handle
 .SH SYNOPSIS

--- a/man3/cxl_afu_opened.3
+++ b/man3/cxl_afu_opened.3
@@ -1,6 +1,6 @@
 .\" Copyright 2015 IBM Corp.
 .\"
-.TH CXL_AFU_OPENED 3 2015-08-15 "LIBCXL 1.2" "CXL Programmer's Manual"
+.TH CXL_AFU_OPENED 3 2016-05-25 "LIBCXL 1.4" "CXL Programmer's Manual"
 .SH NAME
 cxl_afu_opened \- return whether an AFU handle is opened
 .SH SYNOPSIS

--- a/man3/cxl_afu_sysfs_pci.3
+++ b/man3/cxl_afu_sysfs_pci.3
@@ -1,6 +1,6 @@
 .\" Copyright 2015 IBM Corp.
 .\"
-.TH CXL_AFU_SYSFS_PCI 3 2015-08-15 "LIBCXL 1.2" "CXL Programmer's Manual"
+.TH CXL_AFU_SYSFS_PCI 3 2016-05-25 "LIBCXL 1.4" "CXL Programmer's Manual"
 .SH NAME
 cxl_afu_sysfs_pci \- get the sysfs path to the PCI device corresponding with 
 an AFU

--- a/man3/cxl_errinfo_read.3
+++ b/man3/cxl_errinfo_read.3
@@ -1,6 +1,6 @@
 .\" Copyright 2015 IBM Corp.
 .\"
-.TH CXL_ERRINFO_READ 3 2015-08-15 "LIBCXL 1.2" "CXL Programmer's Manual"
+.TH CXL_ERRINFO_READ 3 2016-05-25 "LIBCXL 1.4" "CXL Programmer's Manual"
 .SH NAME
 cxl_errinfo_read \- Read and copy the contents of afu_err_info buffer
 .SH SYNOPSIS

--- a/man3/cxl_errinfo_size.3
+++ b/man3/cxl_errinfo_size.3
@@ -1,6 +1,6 @@
 .\" Copyright 2015 IBM Corp.
 .\"
-.TH CXL_ERRINFO_SIZE 3 2015-08-15 "LIBCXL 1.2" "CXL Programmer's Manual"
+.TH CXL_ERRINFO_SIZE 3 2016-05-25 "LIBCXL 1.4" "CXL Programmer's Manual"
 .SH NAME
 cxl_errinfo_size \- returns the size of afu_err_buff in bytes
 .SH SYNOPSIS

--- a/man3/cxl_event_pending.3
+++ b/man3/cxl_event_pending.3
@@ -1,6 +1,6 @@
 .\" Copyright 2015 IBM Corp.
 .\"
-.TH CXL_EVENT_PENDING 3 2015-08-15 "LIBCXL 1.2" "CXL Programmer's Manual"
+.TH CXL_EVENT_PENDING 3 2016-05-25 "LIBCXL 1.4" "CXL Programmer's Manual"
 .SH NAME
 cxl_event_pending \- return whether a CXL event is pending
 .SH SYNOPSIS

--- a/man3/cxl_fprint_event.3
+++ b/man3/cxl_fprint_event.3
@@ -1,6 +1,6 @@
 .\" Copyright 2015 IBM Corp.
 .\"
-.TH CXL_FPRINT_EVENT 3 2015-08-15 "LIBCXL 1.2" "CXL Programmer's Manual"
+.TH CXL_FPRINT_EVENT 3 2016-05-25 "LIBCXL 1.4" "CXL Programmer's Manual"
 .SH NAME
 cxl_fprint_event \- print out a description of a CXL event for debugging
 .SH SYNOPSIS

--- a/man3/cxl_fprint_unknown_event.3
+++ b/man3/cxl_fprint_unknown_event.3
@@ -1,6 +1,6 @@
 .\" Copyright 2015 IBM Corp.
 .\"
-.TH CXL_FPRINT_UNKNOWN_EVENT 3 2015-08-15 "LIBCXL 1.2" "CXL Manual"
+.TH CXL_FPRINT_UNKNOWN_EVENT 3 2016-05-25 "LIBCXL 1.4" "CXL Manual"
 .SH NAME
 cxl_fprint_unknown_event \- print out a hex dump of a raw CXL event for debugging
 .SH SYNOPSIS

--- a/man3/cxl_get_api_version.3
+++ b/man3/cxl_get_api_version.3
@@ -1,6 +1,6 @@
 .\" Copyright 2015 IBM Corp.
 .\"
-.TH CXL_GET_API_VERSION 3 2015-08-15 "LIBCXL 1.2" "CXL Programmer's Manual"
+.TH CXL_GET_API_VERSION 3 2016-05-25 "LIBCXL 1.4" "CXL Programmer's Manual"
 .SH NAME
 cxl_get_api_version \- get the version of the kernel CXL API
 .SH SYNOPSIS

--- a/man3/cxl_get_api_version_compatible.3
+++ b/man3/cxl_get_api_version_compatible.3
@@ -1,6 +1,6 @@
 .\" Copyright 2015 IBM Corp.
 .\"
-.TH CXL_GET_API_VERSION_COMPATIBLE 3 2015-08-15 "LIBCXL 1.2" "CXL Manual"
+.TH CXL_GET_API_VERSION_COMPATIBLE 3 2016-05-25 "LIBCXL 1.4" "CXL Manual"
 .SH NAME
 cxl_get_api_version_compatible \- get the lowest CXL API version compatible with the kernel
 .SH SYNOPSIS

--- a/man3/cxl_get_base_image.3
+++ b/man3/cxl_get_base_image.3
@@ -1,6 +1,6 @@
 .\" Copyright 2015 IBM Corp.
 .\"
-.TH CXL_GET_BASE_IMAGE 3 2015-08-15 "LIBCXL 1.2" "CXL Programmer's Manual"
+.TH CXL_GET_BASE_IMAGE 3 2016-05-25 "LIBCXL 1.4" "CXL Programmer's Manual"
 .SH NAME
 cxl_get_base_image \- get the revision level of the initial PSL image loaded  on the CXL device
 .SH SYNOPSIS
@@ -36,4 +36,5 @@ Insufficient memory.
 .BR cxl_adapter_next (3),
 .BR cxl_get_caia_version (3),
 .BR cxl_get_image_loaded (3),
-.BR cxl_get_psl_revision (3)
+.BR cxl_get_psl_revision (3),
+.BR cxl_get_psl_timebase_synced (3)

--- a/man3/cxl_get_caia_version.3
+++ b/man3/cxl_get_caia_version.3
@@ -1,6 +1,6 @@
 .\" Copyright 2015 IBM Corp.
 .\"
-.TH CXL_GET_CAIA_VERSION 3 2015-08-15 "LIBCXL 1.2" "CXL Programmer's Manual"
+.TH CXL_GET_CAIA_VERSION 3 2016-05-25 "LIBCXL 1.4" "CXL Programmer's Manual"
 .SH NAME
 cxl_get_caia_version \- get the CAIA version supported by a CXL adapter
 .SH SYNOPSIS
@@ -34,4 +34,5 @@ Insufficient memory.
 .BR cxl_adapter_next (3),
 .BR cxl_get_base_image (3),
 .BR cxl_get_image_loaded (3),
-.BR cxl_get_psl_revision (3)
+.BR cxl_get_psl_revision (3),
+.BR cxl_get_psl_timebase_synced (3)

--- a/man3/cxl_get_cr_class.3
+++ b/man3/cxl_get_cr_class.3
@@ -1,6 +1,6 @@
 .\" Copyright 2015 IBM Corp.
 .\"
-.TH CXL_GET_CR_CLASS 3 2015-08-15 "LIBCXL 1.2" "CXL Programmer's Manual"
+.TH CXL_GET_CR_CLASS 3 2016-05-25 "LIBCXL 1.4" "CXL Programmer's Manual"
 .SH NAME
 cxl_get_cr_class \- get the class code out of an AFU configuration record
 .SH SYNOPSIS

--- a/man3/cxl_get_cr_device.3
+++ b/man3/cxl_get_cr_device.3
@@ -1,6 +1,6 @@
 .\" Copyright 2015 IBM Corp.
 .\"
-.TH CXL_GET_CR_DEVICE 3 2015-08-15 "LIBCXL 1.2" "CXL Programmer's Manual"
+.TH CXL_GET_CR_DEVICE 3 2016-05-25 "LIBCXL 1.4" "CXL Programmer's Manual"
 .SH NAME
 cxl_get_cr_device \- get the device ID out of an AFU configuration record
 .SH SYNOPSIS

--- a/man3/cxl_get_cr_vendor.3
+++ b/man3/cxl_get_cr_vendor.3
@@ -1,6 +1,6 @@
 .\" Copyright 2015 IBM Corp.
 .\"
-.TH CXL_GET_CR_VENDOR 3 2015-08-15 "LIBCXL 1.2" "CXL Programmer's Manual"
+.TH CXL_GET_CR_VENDOR 3 2016-05-25 "LIBCXL 1.4" "CXL Programmer's Manual"
 .SH NAME
 cxl_get_cr_vendor \- get the vendor ID out of an AFU configuration record
 .SH SYNOPSIS

--- a/man3/cxl_get_image_loaded.3
+++ b/man3/cxl_get_image_loaded.3
@@ -1,6 +1,6 @@
 .\" Copyright 2015 IBM Corp.
 .\"
-.TH CXL_GET_IMAGE_LOADED 3 2015-08-15 "LIBCXL 1.2" "CXL Programmer's Manual"
+.TH CXL_GET_IMAGE_LOADED 3 2016-05-25 "LIBCXL 1.4" "CXL Programmer's Manual"
 .SH NAME
 cxl_get_image_loaded \- returns which of the user and factory PSL images is currently loaded on the CXL device
 .SH SYNOPSIS
@@ -38,4 +38,5 @@ Insufficient memory.
 .BR cxl_adapter_next (3),
 .BR cxl_get_base_image (3),
 .BR cxl_get_caia_version (3),
-.BR cxl_get_psl_revision (3)
+.BR cxl_get_psl_revision (3),
+.BR cxl_get_psl_timebase_synced (3)

--- a/man3/cxl_get_irqs_max.3
+++ b/man3/cxl_get_irqs_max.3
@@ -1,6 +1,6 @@
 .\" Copyright 2015 IBM Corp.
 .\"
-.TH CXL_GET_IRQS_MAX 3 2015-08-15 "LIBCXL 1.2" "CXL Programmer's Manual"
+.TH CXL_GET_IRQS_MAX 3 2016-05-25 "LIBCXL 1.4" "CXL Programmer's Manual"
 .SH NAME
 cxl_get_irqs_max \- get the maximum number of AFU interrupts available to a context, if it was the only context running
 .SH SYNOPSIS

--- a/man3/cxl_get_irqs_min.3
+++ b/man3/cxl_get_irqs_min.3
@@ -1,6 +1,6 @@
 .\" Copyright 2015 IBM Corp.
 .\"
-.TH CXL_GET_IRQS_MIN 3 2015-08-15 "LIBCXL 1.2" "CXL Programmer's Manual"
+.TH CXL_GET_IRQS_MIN 3 2016-05-25 "LIBCXL 1.4" "CXL Programmer's Manual"
 .SH NAME
 cxl_get_irqs_min \- get the minimum number of AFU interrupts required for each context
 .SH SYNOPSIS

--- a/man3/cxl_get_mmio_size.3
+++ b/man3/cxl_get_mmio_size.3
@@ -1,6 +1,6 @@
 .\" Copyright 2015 IBM Corp.
 .\"
-.TH CXL_GET_MMIO_SIZE 3 2015-08-15 "LIBCXL 1.2" "CXL Programmer's Manual"
+.TH CXL_GET_MMIO_SIZE 3 2016-05-25 "LIBCXL 1.4" "CXL Programmer's Manual"
 .SH NAME
 cxl_get_mmio_size \- get the total size of the MMIO space of an AFU, including all per-process areas
 .PP

--- a/man3/cxl_get_mode.3
+++ b/man3/cxl_get_mode.3
@@ -1,6 +1,6 @@
 .\" Copyright 2015 IBM Corp.
 .\"
-.TH CXL_GET_MODE 3 2015-08-15 "LIBCXL 1.2" "CXL Programmer's Manual"
+.TH CXL_GET_MODE 3 2016-05-25 "LIBCXL 1.4" "CXL Programmer's Manual"
 .SH NAME
 cxl_get_mode \- get the current programming mode of an AFU
 .SH SYNOPSIS

--- a/man3/cxl_get_modes_supported.3
+++ b/man3/cxl_get_modes_supported.3
@@ -1,6 +1,6 @@
 .\" Copyright 2015 IBM Corp.
 .\"
-.TH CXL_GET_MODES_SUPPORTED 3 2015-08-15 "LIBCXL 1.2" "CXL Programmer's Manual"
+.TH CXL_GET_MODES_SUPPORTED 3 2016-05-25 "LIBCXL 1.4" "CXL Programmer's Manual"
 .SH NAME
 cxl_get_modes_supported \- get the programming modes supported by an AFU
 .SH SYNOPSIS

--- a/man3/cxl_get_pp_mmio_len.3
+++ b/man3/cxl_get_pp_mmio_len.3
@@ -1,6 +1,6 @@
 .\" Copyright 2015 IBM Corp.
 .\"
-.TH CXL_GET_PP_MMIO_LEN 3 2015-08-15 "LIBCXL 1.2" "CXL Programmer's Manual"
+.TH CXL_GET_PP_MMIO_LEN 3 2016-05-25 "LIBCXL 1.4" "CXL Programmer's Manual"
 .SH NAME
 cxl_get_pp_mmio_len \- get the per-process MMIO space length
 .SH SYNOPSIS

--- a/man3/cxl_get_pp_mmio_off.3
+++ b/man3/cxl_get_pp_mmio_off.3
@@ -1,6 +1,6 @@
 .\" Copyright 2015 IBM Corp.
 .\"
-.TH CXL_GET_PP_MMIO_OFF 3 2015-08-15 "LIBCXL 1.2" "CXL Programmer's Manual"
+.TH CXL_GET_PP_MMIO_OFF 3 2016-05-25 "LIBCXL 1.4" "CXL Programmer's Manual"
 .SH NAME
 cxl_get_pp_mmio_off \- get the per-process MMIO space offset
 .SH SYNOPSIS

--- a/man3/cxl_get_prefault_mode.3
+++ b/man3/cxl_get_prefault_mode.3
@@ -1,6 +1,6 @@
 .\" Copyright 2015 IBM Corp.
 .\"
-.TH CXL_GET_PREFAULT_MODE 3 2015-08-15 "LIBCXL 1.2" "CXL Programmer's Manual"
+.TH CXL_GET_PREFAULT_MODE 3 2016-05-25 "LIBCXL 1.4" "CXL Programmer's Manual"
 .SH NAME
 cxl_get_prefault_mode \- get the mode for prefaulting segments
 .SH SYNOPSIS

--- a/man3/cxl_get_psl_revision.3
+++ b/man3/cxl_get_psl_revision.3
@@ -1,6 +1,6 @@
 .\" Copyright 2015 IBM Corp.
 .\"
-.TH CXL_GET_PSL_REVISION 3 2015-08-15 "LIBCXL 1.2" "CXL Programmer's Manual"
+.TH CXL_GET_PSL_REVISION 3 2016-05-25 "LIBCXL 1.4" "CXL Programmer's Manual"
 .SH NAME
 cxl_get_psl_revision \- get the revision level of the current PSL image loaded on the CXL device
 .SH SYNOPSIS
@@ -32,3 +32,4 @@ Insufficient memory.
 .BR cxl_get_base_image (3),
 .BR cxl_get_caia_version (3),
 .BR cxl_get_image_loaded (3)
+.BR cxl_get_psl_timebase_synced (3)

--- a/man3/cxl_get_psl_timebase_synced.3
+++ b/man3/cxl_get_psl_timebase_synced.3
@@ -1,0 +1,40 @@
+.\" Copyright 2015 IBM Corp.
+.\"
+.TH CXL_GET_PSL_TIMEBASE_SYNCED 3 2016-05-25 "LIBCXL 1.4" "CXL Manual"
+.SH NAME
+cxl_get_psl_timebase_synced \- get the status of timebase on the CXL device
+.SH SYNOPSIS
+.B #include <libcxl.h>
+.PP
+.B "int cxl_get_psl_timebase_synced(struct cxl_adapter_h"
+.BI * adapter ", long *" valp );
+.SH DESCRIPTION
+.BR cxl_get_psl_timebase_synced ()
+copies the status of timebase on the CXL
+.I adapter
+to the long integer pointed to by
+.IR valp .
+This value will be 1 if the PSL timebase register is synchronized
+with the core timebase register, 0 otherwise.
+.SH RETURN VALUE
+On success, 0 is returned.
+On error, \-1 is returned and
+.I errno
+is set appropriately.
+.SH ERRORS
+.TP
+.B EINVAL
+Invalid argument value.
+.TP
+.B ENODEV
+The kernel does not export the PSL timebase status.
+.TP
+.B ENOMEM
+Insufficient memory.
+.SH SEE ALSO
+.BR cxl (3),
+.BR cxl_adapter_next (3),
+.BR cxl_get_base_image (3),
+.BR cxl_get_caia_version (3),
+.BR cxl_get_image_loaded (3),
+.BR cxl_get_psl_revision (3)

--- a/man3/cxl_mmio_map.3
+++ b/man3/cxl_mmio_map.3
@@ -1,6 +1,6 @@
 .\" Copyright 2015 IBM Corp.
 .\"
-.TH CXL_MMIO_MAP 3 2015-08-15 "LIBCXL 1.2" "CXL Programmer's Manual"
+.TH CXL_MMIO_MAP 3 2016-05-25 "LIBCXL 1.4" "CXL Programmer's Manual"
 .SH NAME
 cxl_mmio_map \- map the per-process Problem State Area of an AFU to memory
 .SH SYNOPSIS

--- a/man3/cxl_mmio_ptr.3
+++ b/man3/cxl_mmio_ptr.3
@@ -1,6 +1,6 @@
 .\" Copyright 2015 IBM Corp.
 .\"
-.TH CXL_MMIO_PTR 3 2015-08-15 "LIBCXL 1.2" "CXL Programmer's Manual"
+.TH CXL_MMIO_PTR 3 2016-05-25 "LIBCXL 1.4" "CXL Programmer's Manual"
 .SH NAME
 cxl_mmio_ptr \- return the address of the mapped AFU Problem State Area
 .SH SYNOPSIS

--- a/man3/cxl_mmio_read32.3
+++ b/man3/cxl_mmio_read32.3
@@ -1,6 +1,6 @@
 .\" Copyright 2015 IBM Corp.
 .\"
-.TH CXL_MMIO_READ32 3 2015-08-15 "LIBCXL 1.2" "CXL Programmer's Manual"
+.TH CXL_MMIO_READ32 3 2016-05-25 "LIBCXL 1.4" "CXL Programmer's Manual"
 .SH NAME
 cxl_mmio_read32 \- read a 32-bit word from the mapped AFU Problem State Area
 .SH SYNOPSIS

--- a/man3/cxl_mmio_read64.3
+++ b/man3/cxl_mmio_read64.3
@@ -1,6 +1,6 @@
 .\" Copyright 2015 IBM Corp.
 .\"
-.TH CXL_MMIO_READ64 3 2015-08-15 "LIBCXL 1.2" "CXL Programmer's Manual"
+.TH CXL_MMIO_READ64 3 2016-05-25 "LIBCXL 1.4" "CXL Programmer's Manual"
 .SH NAME
 cxl_mmio_read64 \- read a 64-bit word from the mapped AFU Problem State Area
 .SH SYNOPSIS

--- a/man3/cxl_mmio_unmap.3
+++ b/man3/cxl_mmio_unmap.3
@@ -1,6 +1,6 @@
 .\" Copyright 2015 IBM Corp.
 .\"
-.TH CXL_MMIO_UNMAP 3 2015-08-15 "LIBCXL 1.2" "CXL Programmer's Manual"
+.TH CXL_MMIO_UNMAP 3 2016-05-25 "LIBCXL 1.4" "CXL Programmer's Manual"
 .SH NAME
 cxl_mmio_unmap \- unmap an AFU Problem State Area
 .SH SYNOPSIS

--- a/man3/cxl_mmio_write32.3
+++ b/man3/cxl_mmio_write32.3
@@ -1,6 +1,6 @@
 .\" Copyright 2015 IBM Corp.
 .\"
-.TH CXL_MMIO_WRITE32 3 2015-08-15 "LIBCXL 1.2" "CXL Programmer's Manual"
+.TH CXL_MMIO_WRITE32 3 2016-05-25 "LIBCXL 1.4" "CXL Programmer's Manual"
 .SH NAME
 cxl_mmio_write32 \- write a 32-bit word to the mapped AFU Problem State Area
 .SH SYNOPSIS

--- a/man3/cxl_mmio_write64.3
+++ b/man3/cxl_mmio_write64.3
@@ -1,6 +1,6 @@
 .\" Copyright 2015 IBM Corp.
 .\"
-.TH CXL_MMIO_WRITE64 3 2015-08-15 "LIBCXL 1.2" "CXL Programmer's Manual"
+.TH CXL_MMIO_WRITE64 3 2016-05-25 "LIBCXL 1.4" "CXL Programmer's Manual"
 .SH NAME
 cxl_mmio_write64 \- write a 64-bit word to the mapped AFU Problem State Area
 .SH SYNOPSIS

--- a/man3/cxl_read_event.3
+++ b/man3/cxl_read_event.3
@@ -1,6 +1,6 @@
 .\" Copyright 2015 IBM Corp.
 .\"
-.TH CXL_READ_EVENT 3 2015-08-15 "LIBCXL 1.2" "CXL Programmer's Manual"
+.TH CXL_READ_EVENT 3 2016-05-25 "LIBCXL 1.4" "CXL Programmer's Manual"
 .SH NAME
 cxl_read_event \- read one CXL event from an AFU
 .SH SYNOPSIS

--- a/man3/cxl_read_expected_event.3
+++ b/man3/cxl_read_expected_event.3
@@ -1,6 +1,6 @@
 .\" Copyright 2015 IBM Corp.
 .\"
-.TH CXL_READ_EXPECTED_EVENT 3 2015-08-15 "LIBCXL 1.2" "CXL Manual"
+.TH CXL_READ_EXPECTED_EVENT 3 2016-05-25 "LIBCXL 1.4" "CXL Manual"
 .SH NAME
 cxl_read_expected_event \- read one CXL event from an AFU, and treat it as a failure, if it did not match an expected event
 .SH SYNOPSIS

--- a/man3/cxl_set_irqs_max.3
+++ b/man3/cxl_set_irqs_max.3
@@ -1,6 +1,6 @@
 .\" Copyright 2015 IBM Corp.
 .\"
-.TH CXL_SET_IRQS_MAX 3 2015-08-15 "LIBCXL 1.2" "CXL Programmer's Manual"
+.TH CXL_SET_IRQS_MAX 3 2016-05-25 "LIBCXL 1.4" "CXL Programmer's Manual"
 .SH NAME
 cxl_set_irqs_max \- administratively restrict the maximum number of AFU interrupts
 .SH SYNOPSIS

--- a/man3/cxl_set_mode.3
+++ b/man3/cxl_set_mode.3
@@ -1,6 +1,6 @@
 .\" Copyright 2015 IBM Corp.
 .\"
-.TH CXL_SET_MODE 3 2015-08-15 "LIBCXL 1.2" "CXL Programmer's Manual"
+.TH CXL_SET_MODE 3 2016-05-25 "LIBCXL 1.4" "CXL Programmer's Manual"
 .SH NAME
 cxl_set_mode \- set the programming mode of an AFU
 .SH SYNOPSIS

--- a/man3/cxl_set_prefault_mode.3
+++ b/man3/cxl_set_prefault_mode.3
@@ -1,6 +1,6 @@
 .\" Copyright 2015 IBM Corp.
 .\"
-.TH CXL_SET_PREFAULT_MODE 3 2015-08-15 "LIBCXL 1.2" "CXL Programmer's Manual"
+.TH CXL_SET_PREFAULT_MODE 3 2016-05-25 "LIBCXL 1.4" "CXL Programmer's Manual"
 .SH NAME
 cxl_set_prefault_mode \- set the mode for prefaulting segments
 .SH SYNOPSIS

--- a/man3/cxl_work_alloc.3
+++ b/man3/cxl_work_alloc.3
@@ -1,6 +1,6 @@
 .\" Copyright 2015 IBM Corp.
 .\"
-.TH CXL_WORK_ALLOC 3 2015-08-15 "LIBCXL 1.2" "CXL Programmer's Manual"
+.TH CXL_WORK_ALLOC 3 2016-05-25 "LIBCXL 1.4" "CXL Programmer's Manual"
 .SH NAME
 cxl_work_alloc \- allocate and initialize a work structure
 .SH SYNOPSIS

--- a/man3/cxl_work_free.3
+++ b/man3/cxl_work_free.3
@@ -1,6 +1,6 @@
 .\" Copyright 2015 IBM Corp.
 .\"
-.TH CXL_WORK_FREE 3 2015-08-15 "LIBCXL 1.2" "CXL Programmer's Manual"
+.TH CXL_WORK_FREE 3 2016-05-25 "LIBCXL 1.4" "CXL Programmer's Manual"
 .SH NAME
 cxl_work_get_free \- free a work structure
 .SH SYNOPSIS

--- a/man3/cxl_work_get_amr.3
+++ b/man3/cxl_work_get_amr.3
@@ -1,6 +1,6 @@
 .\" Copyright 2015 IBM Corp.
 .\"
-.TH CXL_WORK_GET_AMR 3 2015-08-15 "LIBCXL 1.2" "CXL Programmer's Manual"
+.TH CXL_WORK_GET_AMR 3 2016-05-25 "LIBCXL 1.4" "CXL Programmer's Manual"
 .SH NAME
 cxl_work_get_amr \- get the value of the authority mask register
 .SH SYNOPSIS

--- a/man3/cxl_work_get_num_irqs.3
+++ b/man3/cxl_work_get_num_irqs.3
@@ -1,6 +1,6 @@
 .\" Copyright 2015 IBM Corp.
 .\"
-.TH CXL_WORK_GET_NUM_IRQS 3 2015-08-15 "LIBCXL 1.2" "CXL Programmer's Manual"
+.TH CXL_WORK_GET_NUM_IRQS 3 2016-05-25 "LIBCXL 1.4" "CXL Programmer's Manual"
 .SH NAME
 cxl_work_get_num_irqs \- get the number of interrupts requested
 .SH SYNOPSIS

--- a/man3/cxl_work_get_wed.3
+++ b/man3/cxl_work_get_wed.3
@@ -1,6 +1,6 @@
 .\" Copyright 2015 IBM Corp.
 .\"
-.TH CXL_WORK_GET_WED 3 2015-08-15 "LIBCXL 1.2" "CXL Programmer's Manual"
+.TH CXL_WORK_GET_WED 3 2016-05-25 "LIBCXL 1.4" "CXL Programmer's Manual"
 .SH NAME
 cxl_work_get_wed \- get the value of the work element descriptor
 .SH SYNOPSIS

--- a/man3/cxl_work_set_amr.3
+++ b/man3/cxl_work_set_amr.3
@@ -1,6 +1,6 @@
 .\" Copyright 2015 IBM Corp.
 .\"
-.TH CXL_WORK_SET_AMR 3 2015-08-15 "LIBCXL 1.2" "CXL Programmer's Manual"
+.TH CXL_WORK_SET_AMR 3 2016-05-25 "LIBCXL 1.4" "CXL Programmer's Manual"
 .SH NAME
 cxl_work_set_amr \- set the value of the authority mask register
 .SH SYNOPSIS

--- a/man3/cxl_work_set_num_irqs.3
+++ b/man3/cxl_work_set_num_irqs.3
@@ -1,6 +1,6 @@
 .\" Copyright 2015 IBM Corp.
 .\"
-.TH CXL_WORK_SET_NUM_IRQS 3 2015-08-15 "LIBCXL 1.2" "CXL Programmer's Manual"
+.TH CXL_WORK_SET_NUM_IRQS 3 2016-05-25 "LIBCXL 1.4" "CXL Programmer's Manual"
 .SH NAME
 cxl_work_set_num_irqs \- set the number of interrupts requested
 .SH SYNOPSIS

--- a/man3/cxl_work_set_wed.3
+++ b/man3/cxl_work_set_wed.3
@@ -1,6 +1,6 @@
 .\" Copyright 2015 IBM Corp.
 .\"
-.TH CXL_WORK_SET_WED 3 2015-08-15 "LIBCXL 1.2" "CXL Programmer's Manual"
+.TH CXL_WORK_SET_WED 3 2016-05-25 "LIBCXL 1.4" "CXL Programmer's Manual"
 .SH NAME
 cxl_work_set_wed \- set the value of the work element descriptor
 .SH SYNOPSIS

--- a/symver.map
+++ b/symver.map
@@ -85,3 +85,8 @@ LIBCXL_1.2 {
 
 		cxl_event_pending;
 } LIBCXL_1.1;
+
+LIBCXL_1.4 {
+	global:
+		cxl_get_psl_timebase_synced;
+} LIBCXL_1.2;


### PR DESCRIPTION
Returns the status of timebase on the CXL device.

Signed-off-by: Philippe Bergheaud felix@linux.vnet.ibm.com
