### PR TITLE
Create LIBSONAME link

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ VERS_SONAME=1
 LIBSONAME = libcxl.so.$(VERS_SONAME)
 SONAMEOPT = -Wl,-soname,$(LIBSONAME)
 
-all: check_cxl_header $(LIBNAME) libcxl.so libcxl.a
+all: check_cxl_header $(LIBSONAME) libcxl.so libcxl.a
 
 HAS_WGET = $(shell /bin/which wget > /dev/null 2>&1 && echo y || echo n)
 HAS_CURL = $(shell /bin/which curl > /dev/null 2>&1 && echo y || echo n)
@@ -39,6 +39,9 @@ libcxl.o libcxl_sysfs.o : CFLAGS += -fPIC
 libcxl.so: $(LIBNAME)
 	ln -s $(LIBNAME) libcxl.so
 
+$(LIBSONAME): $(LIBNAME)
+	ln -s $(LIBNAME) $(LIBSONAME)
+
 $(LIBNAME): libcxl.o libcxl_sysfs.o symver.map
 	$(call Q,CC, $(CC) $(CFLAGS) $(LDFLAGS) -shared libcxl.o libcxl_sysfs.o -o $(LIBNAME), $(LIBNAME)) -Wl,--version-script symver.map $(SONAMEOPT)
 
@@ -48,13 +51,13 @@ libcxl.a: libcxl.o libcxl_sysfs.o
 include Makefile.rules
 
 clean:
-	rm -f *.o *.d libcxl.so libcxl.a include/misc/cxl.h
+	rm -f *.o *.d libcxl.so* libcxl.a include/misc/cxl.h
 
 install: all
 	mkdir -p $(DESTDIR)$(libdir)
 	mkdir -p $(DESTDIR)$(includedir)
 	install -m 0755 $(LIBNAME) $(DESTDIR)$(libdir)/
-	cp -d libcxl.so $(DESTDIR)$(libdir)/
+	cp -d libcxl.so $(LIBSONAME) $(DESTDIR)$(libdir)/
 	install -m 0644 libcxl.h  $(DESTDIR)$(includedir)/
 
 .PHONY: clean all install


### PR DESCRIPTION
For the packaging, we should not only include the shared library itself, but
also the symbolic link which ldconfig would produce. (This is necessary, so
that the link gets removed by dpkg, for ex., automatically when the package gets
removed.) And the packaging doesn't have to deal with the soname version, so
putting this in the Makefile while waiting.
Also updating the all and clean targets.
