### PR TITLE
sysfs: Fix a boundary condition check for OUT_OF_RANGE macro

### DIFF
--- a/libcxl_sysfs.c
+++ b/libcxl_sysfs.c
@@ -94,7 +94,7 @@ static struct cxl_sysfs_entry sysfs_entry[CXL_ATTR_MAX] = {
 	[PSL_REVISION] = { "psl_revision", scan_int, 1 },
 };
 
-#define OUT_OF_RANGE(attr) ((attr) < 0 || (attr) > CXL_ATTR_MAX || \
+#define OUT_OF_RANGE(attr) ((attr) < 0 || (attr) >= CXL_ATTR_MAX || \
 			    (sysfs_entry[attr].name == NULL))
 
 static int scan_int(char *attr_str, long *majorp, long *minorp)


### PR DESCRIPTION
This fixes an off by one boundary condition check failure in the
definition of OUT_OF_RANGE.

Reported-by: Frank Haverkamp haver@linux.vnet.ibm.com
Signed-off-by: Vaibhav Jain vaibhav@linux.vnet.ibm.com
