### PR TITLE
Install static libraries also

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,7 @@ install: all
 	mkdir -p $(DESTDIR)$(includedir)
 	install -m 0755 $(LIBNAME) $(DESTDIR)$(libdir)/
 	cp -d libcxl.so $(DESTDIR)$(libdir)/
+	cp -d libcxl.a $(LIBSONAME) $(DESTDIR)$(libdir)/
 	install -m 0644 libcxl.h  $(DESTDIR)$(includedir)/
 
 .PHONY: clean all install


### PR DESCRIPTION
Currently libcxl static library is being generated but not being
installed which causes some proble, as being reported at:

https://bugs.launchpad.net/ubuntu/+source/libcxl/+bug/1590503

This patch just install the static library together with shared
objects.

This change should be applied on top of Fred's PR #15:
https://github.com/ibm-capi/libcxl/pull/15
