### PR TITLE
Added #include <asm/types.h>

### DIFF
--- a/libcxl_internal.h
+++ b/libcxl_internal.h
@@ -17,6 +17,7 @@
 #ifndef _LIBCXL_INTERNAL_H
 #define _LIBCXL_INTERNAL_H
 
+#include <asm/types.h>
 #include <sys/types.h>
 #include <dirent.h>
 


### PR DESCRIPTION
This include file is necessary for __u32 type to be defined, when compiling with strict compilers.