### PR TITLE
Miscellaneous warning fixes

### DIFF
--- a/Makefile.vars
+++ b/Makefile.vars
@@ -4,8 +4,9 @@ MAKEFLAGS += -rR
 AS	= $(CROSS_COMPILE)as
 LD	= $(CROSS_COMPILE)ld
 CC	= $(CROSS_COMPILE)gcc
+CFLAGS	+= -g -Wall -Werror -O2 -I$(CURDIR)
 ifeq ($(BIT32),y)
-CFLAGS += -g -Wall -O2 -m32 -I$(CURDIR)
+CFLAGS += -m32
 else
-CFLAGS += -g -Wall -O2 -m64 -I$(CURDIR)
+CFLAGS += -m64
 endif

--- a/libcxl.c
+++ b/libcxl.c
@@ -15,7 +15,7 @@
  */
 
 #define _GNU_SOURCE /* For asprintf */
-#define _BSD_SOURCE
+#define _DEFAULT_SOURCE
 #define __STDC_FORMAT_MACROS
 
 #include <inttypes.h>


### PR DESCRIPTION
Fix a bunch of sparse and compiler warnings, enable -Wall -Werror because it's generally a good idea.

Signed-off-by: Andrew Donnellan <andrew.donnellan@au1.ibm.com>