### PR TITLE
libcxl: Check afu link when read from PSA mmio return all FFs

### DIFF
--- a/libcxl.c
+++ b/libcxl.c
@@ -91,6 +91,8 @@ static struct cxl_afu_h * malloc_afu(void)
 	afu->sysfs_path = NULL;
 	afu->fd_errbuff = -1;
 	afu->errbuff_size = -1;
+	afu->fd_afudesc = -1;
+	afu->mmio_afudesc = MAP_FAILED;
 
 	return afu;
 }
@@ -197,6 +199,9 @@ static void _cxl_afu_free(struct cxl_afu_h *afu, int free_adapter)
 {
 	if (!afu)
 		return;
+
+	cxl_close_afudesc(afu);
+
 	if (afu->enum_dir)
 		closedir(afu->enum_dir);
 	if (afu->sysfs_path)
@@ -481,6 +486,12 @@ static int open_afu_dev(struct cxl_afu_h *afu, char *path)
 	if (api_version > CXL_KERNEL_API_VERSION) {
 		errno = EPROTO;
 		goto err_close;
+	}
+
+	 /* try opening the afu descriptor attr. Don't fail if we can't. */
+	if (cxl_open_afudesc(afu)) {
+		pr_devel("Unable to open afu_desc for %s. Won't support mmio reads with all FFFFs"
+			 , afu->dev_name);
 	}
 	return 0;
 
@@ -1115,6 +1126,17 @@ static inline uint32_t _cxl_mmio_read32(struct cxl_afu_h *afu, uint64_t offset)
 	return d;
 }
 
+/* Check if the card link if up */
+static inline int cxl_afu_link_ok(struct cxl_afu_h *afu)
+{
+	/* if afu desc not available then assume the link is down */
+	if (afu->fd_afudesc < 0)
+		return 0;
+
+	/* check if first word in afu_desc is all 0xfffs */
+	return ~(*afu->mmio_afudesc) != 0;
+}
+
 int cxl_mmio_write64(struct cxl_afu_h *afu, uint64_t offset, uint64_t data)
 {
 	if (!afu || !afu->mmio_addr)
@@ -1166,7 +1188,7 @@ int cxl_mmio_read64(struct cxl_afu_h *afu, uint64_t offset, uint64_t *data)
 	d = _cxl_mmio_read64(afu, offset);
 	cxl_mmio_success();
 
-	if (d == 0xffffffffffffffffull)
+	if (d == 0xffffffffffffffffull && !cxl_afu_link_ok(afu))
 		goto fail;
 
 	*data = d;
@@ -1244,7 +1266,7 @@ int cxl_mmio_read32(struct cxl_afu_h *afu, uint64_t offset, uint32_t *data)
 	d = _cxl_mmio_read32(afu, offset);
 	cxl_mmio_success();
 
-	if (d == 0xffffffff)
+	if (d == 0xffffffff && !cxl_afu_link_ok(afu))
 		goto fail;
 
 	*data = d;

--- a/libcxl_internal.h
+++ b/libcxl_internal.h
@@ -43,8 +43,18 @@ struct cxl_afu_h {
 	size_t mmio_size;
 	int fd_errbuff; /* fd to the afu_err_buff */
 	size_t errbuff_size;
+
+	/* mapped afu descriptor */
+	int fd_afudesc;
+	__u64 *mmio_afudesc;
 };
 
 int cxl_get_dev(struct cxl_afu_h *afu, long *majorp, long *minorp);
+
+
+/* Init and cleanup functions for mapping afu-desc to process addr space. */
+int cxl_open_afudesc(struct cxl_afu_h *afu);
+
+void cxl_close_afudesc(struct cxl_afu_h *afu);
 
 #endif

--- a/libcxl_sysfs.c
+++ b/libcxl_sysfs.c
@@ -23,6 +23,7 @@
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <errno.h>
+#include <sys/mman.h>
 
 #include <misc/cxl.h>
 #include "libcxl.h"
@@ -575,4 +576,55 @@ ssize_t cxl_errinfo_read(struct cxl_afu_h *afu, void *dst, off_t off,
 		return -1;
 
 	return read(afu->fd_errbuff, dst, len);
+}
+
+/* Get the path to afu desc and open handle to it */
+int cxl_open_afudesc(struct cxl_afu_h *afu)
+{
+	int rc = -1;
+	char *path;
+
+	/* already mapped and opened */
+	if (afu->fd_afudesc >= 0)
+		return 0;
+
+	path = sysfs_get_path(afu->sysfs_path, "afu_desc");
+	if (!path)
+		goto out;
+
+	rc = open(path, O_RDONLY |  O_CLOEXEC);
+	if (rc < 0)
+		goto out;
+
+	/* mmap the first page of the afu descriptor */
+	afu->mmio_afudesc = mmap(NULL, sysconf(_SC_PAGESIZE), PROT_READ,
+				 MAP_SHARED, rc, 0);
+
+	if (afu->mmio_afudesc == MAP_FAILED) {
+		close(rc);
+		rc = -1;
+		goto out;
+	}
+
+	afu->fd_afudesc = rc;
+	rc = 0;
+
+out:
+	if (path != NULL)
+		free(path);
+
+	return rc;
+}
+
+/* close the afu desc file handle and mapping */
+void cxl_close_afudesc(struct cxl_afu_h *afu)
+{
+	/* Bail out, if we didn't or were not able to do the mapping */
+	if (afu->fd_afudesc < 0)
+		return;
+
+	munmap(afu->mmio_afudesc, sysconf(_SC_PAGE_SIZE));
+	close(afu->fd_afudesc);
+	afu->fd_afudesc = -1;
+	afu->mmio_afudesc = MAP_FAILED;
 }


### PR DESCRIPTION
Presently libcxl will return an error or raise a SIGBUS when it reads
all FFs from PSA mmio space. This prevents returning wrong values to
the caller when the CXL card has fenced due to an eeh error. But this
posses problems as for some AFUs all FFs might be a valid value for a
PSA register and when read libcxl might incorrectly assume the card to
be fenced and indicate an error to the caller.

We fix this problem by memory mapping the afu descriptor from sysfs to
the process address. When libcxl mmio space read functions
cxl_mmio_read{64,32}() read all FFs we check the first word of the
mapped afu descriptor to see if it all FFs. If yes we assume the card
has fenced and we return an error to the caller. Else we assume the
read value as valid and return a success to the caller with all FFs as
result.

This patch introduces three new internal functions:

* cxl_open_afudesc(): Maps the afu sysfs attr named 'afu_desc' to
  process address space.

* cxl_close_afudesc(): Unmaps and closes the afu descriptor from the
  process address space.

* cxl_afu_link_ok(): Reads the first word from mapped afu descriptor
  and returns 1 if its *not* all FFs else returns 0 indicating link
  down. In case there was an error mapping afu_desc it returns '0'

Signed-off-by: Vaibhav Jain <vaibhav@linux.vnet.ibm.com>