### PR TITLE
libcxl sysmacros

### DIFF
--- a/libcxl.c
+++ b/libcxl.c
@@ -32,6 +32,7 @@
 #include <poll.h>
 
 #include <sys/ioctl.h>
+#include <sys/sysmacros.h>
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <sys/wait.h>


### PR DESCRIPTION
to avoid warning like:
```
libcxl.c:250:13: warning: In the GNU C Library, "major" is defined
 by <sys/sysmacros.h>. For historical compatibility, it is
 currently defined by <sys/types.h> as well, but we plan to
 remove this soon. To use "major", include <sys/sysmacros.h>
 directly. If you did not intend to use a system-defined macro
 "major", you should undefine it after including <sys/types.h>.
   return asprintf(bufp, "/sys/dev/char/%i:%i", major(sb.st_rdev),
```

Signed-off-by: Michel Normand <normand@linux.vnet.ibm.com>