### PR TITLE
New api cxl_get_tunneled_ops_supported()

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ OBJS = libcxl.o libcxl_sysfs.o
 CFLAGS += -I include
 
 # change VERS_LIB if new git tag
-VERS_LIB = 1.6
+VERS_LIB = 1.7
 LIBNAME   = libcxl.so.$(VERS_LIB)
 # change VERS_SONAME only if library breaks backward compatibility.
 # refer to file symver.map

--- a/libcxl.h
+++ b/libcxl.h
@@ -182,6 +182,7 @@ int cxl_get_caia_version(struct cxl_adapter_h *adapter, long *majorp,
 int cxl_get_image_loaded(struct cxl_adapter_h *adapter, enum cxl_image *valp);
 int cxl_get_psl_revision(struct cxl_adapter_h *adapter, long *valp);
 int cxl_get_psl_timebase_synced(struct cxl_adapter_h *adapter, long *valp);
+int cxl_get_tunneled_ops_supported(struct cxl_adapter_h *adapter, long *valp);
 
 /*
  * Events
@@ -257,9 +258,9 @@ ssize_t cxl_errinfo_read(struct cxl_afu_h *afu, void *dst, off_t off,
 #if defined CXL_START_WORK_TID
 /**
  * Execute the instruction "wait" while the value of the shared
- * memory (uworld) has not changed. Only the current thread, which has
+ * memory (uword) has not changed. Only the current thread, which has
  * attached the work, may be asleep.
- * @param uworld Pointer to the shared memory to exit from the loop.
+ * @param uword Pointer to the shared memory to exit from the loop.
  * @return In case of success '0' is returned. In case of an error or
  * the afu doesn't exist, -1 is returned and errno is set
  * appropriately.

--- a/libcxl_sysfs.c
+++ b/libcxl_sysfs.c
@@ -54,6 +54,7 @@ enum cxl_sysfs_attr {
 	IMAGE_LOADED,
 	PSL_REVISION,
 	PSL_TIMEBASE_SYNCED,
+	TUNNELED_OPS_SUPPORTED,
 
 	/* Add new attrs above this */
 	CXL_ATTR_MAX
@@ -94,6 +95,7 @@ static struct cxl_sysfs_entry sysfs_entry[CXL_ATTR_MAX] = {
 	[IMAGE_LOADED] = { "image_loaded", scan_image, 1 },
 	[PSL_REVISION] = { "psl_revision", scan_int, 1 },
 	[PSL_TIMEBASE_SYNCED] = { "psl_timebase_synced", scan_int, 1 },
+	[TUNNELED_OPS_SUPPORTED] = { "tunneled_ops_supported", scan_int, 1 },
 };
 
 #define OUT_OF_RANGE(attr) ((attr) < 0 || (attr) >= CXL_ATTR_MAX || \
@@ -434,6 +436,11 @@ int cxl_get_psl_revision(struct cxl_adapter_h *adapter, long *valp)
 int cxl_get_psl_timebase_synced(struct cxl_adapter_h *adapter, long *valp)
 {
 	return read_sysfs_adapter(adapter, PSL_TIMEBASE_SYNCED, valp, NULL);
+}
+
+int cxl_get_tunneled_ops_supported(struct cxl_adapter_h *adapter, long *valp)
+{
+	return read_sysfs_adapter(adapter, TUNNELED_OPS_SUPPORTED, valp, NULL);
 }
 
 static int write_sysfs_str(char *path, enum cxl_sysfs_attr attr, char *str)

--- a/man3/cxl.3
+++ b/man3/cxl.3
@@ -1,6 +1,6 @@
 .\" Copyright 2015-2018 IBM Corp.
 .\"
-.TH CXL 3 2018-04-24 "LIBCXL 1.6" "CXL Programmer's Manual"
+.TH CXL 3 2018-04-26 "LIBCXL 1.7" "CXL Programmer's Manual"
 .SH NAME
 cxl \- Coherent Accelerator Interface (CXL) library functions
 .SH SYNOPSIS
@@ -142,6 +142,8 @@ cxl_get_base_image	get the revision level of the initial PSL image loaded on the
 cxl_get_caia_version	get the CAIA version supported by a CXL adapter
 cxl_get_image_loaded	returns which of the user and factory PSL images is currently loaded on the CXL device
 cxl_get_psl_revision	get the revision level of the current PSL image loaded on the CXL device
+cxl_get_psl_timebase_synced	get the status of timebase on the CXL device
+cxl_get_tunneled_ops_supported	get the status of tunneled operations on the CXL device
 .TE
 .SS AFU Directed Master Context Sysfs Helper functions
 .TS
@@ -264,6 +266,7 @@ cxl_errinfo_size	returns the size of afu_err_buff in bytes
 .BR cxl_get_prefault_mode (3),
 .BR cxl_get_psl_revision (3),
 .BR cxl_get_psl_timebase_synced (3),
+.BR cxl_get_tunneled_ops_supported (3),
 .BR cxl_mmio_install_sigbus_handler (3),
 .BR cxl_mmio_map (3),
 .BR cxl_mmio_ptr (3),

--- a/man3/cxl_adapter_next.3
+++ b/man3/cxl_adapter_next.3
@@ -60,4 +60,5 @@ CXL adapters:
 .BR cxl_get_caia_version (3),
 .BR cxl_get_image_loaded (3),
 .BR cxl_get_psl_revision (3),
-.BR cxl_get_psl_timebase_synced (3)
+.BR cxl_get_psl_timebase_synced (3),
+.BR cxl_get_tunneled_ops_supported (3)

--- a/man3/cxl_afu_host_thread_wait.3
+++ b/man3/cxl_afu_host_thread_wait.3
@@ -9,6 +9,9 @@ cxl_afu_host_thread_wait \- wait for AFU notification
 .B "int afu_host_thread_wait(struct cxl_afu_h"
 .BI * afu ", volatile __u64 *" uword );
 .SH DESCRIPTION
+The tunneled operation as_notify is supported on POWER9. See
+.BR cxl_get_tunneled_ops_supported ().
+.PP
 The thread calling
 .BR afu_host_thread_wait ()
 executes the instruction "wait" and goes to sleep.
@@ -49,6 +52,7 @@ AFU context not attached by current thread, or wait not enabled
 .BR cxl (3),
 .BR cxl_afu_attach_work (3),
 .BR cxl_afu_host_thread_wait (3),
+.BR cxl_get_tunneled_ops_supported (3),
 .BR cxl_work_disable_wait (3),
 .BR cxl_work_enable_wait (3),
 .BR cxl_work_get_tid (3)

--- a/man3/cxl_get_base_image.3
+++ b/man3/cxl_get_base_image.3
@@ -37,4 +37,5 @@ Insufficient memory.
 .BR cxl_get_caia_version (3),
 .BR cxl_get_image_loaded (3),
 .BR cxl_get_psl_revision (3),
-.BR cxl_get_psl_timebase_synced (3)
+.BR cxl_get_psl_timebase_synced (3),
+.BR cxl_get_tunneled_ops_supported (3)

--- a/man3/cxl_get_caia_version.3
+++ b/man3/cxl_get_caia_version.3
@@ -35,4 +35,5 @@ Insufficient memory.
 .BR cxl_get_base_image (3),
 .BR cxl_get_image_loaded (3),
 .BR cxl_get_psl_revision (3),
-.BR cxl_get_psl_timebase_synced (3)
+.BR cxl_get_psl_timebase_synced (3),
+.BR cxl_get_tunneled_ops_supported (3)

--- a/man3/cxl_get_image_loaded.3
+++ b/man3/cxl_get_image_loaded.3
@@ -39,4 +39,5 @@ Insufficient memory.
 .BR cxl_get_base_image (3),
 .BR cxl_get_caia_version (3),
 .BR cxl_get_psl_revision (3),
-.BR cxl_get_psl_timebase_synced (3)
+.BR cxl_get_psl_timebase_synced (3),
+.BR cxl_get_tunneled_ops_supported (3)

--- a/man3/cxl_get_psl_revision.3
+++ b/man3/cxl_get_psl_revision.3
@@ -32,4 +32,5 @@ Insufficient memory.
 .BR cxl_get_base_image (3),
 .BR cxl_get_caia_version (3),
 .BR cxl_get_image_loaded (3)
-.BR cxl_get_psl_timebase_synced (3)
+.BR cxl_get_psl_timebase_synced (3),
+.BR cxl_get_tunneled_ops_supported (3)

--- a/man3/cxl_get_psl_timebase_synced.3
+++ b/man3/cxl_get_psl_timebase_synced.3
@@ -37,4 +37,5 @@ Insufficient memory.
 .BR cxl_get_base_image (3),
 .BR cxl_get_caia_version (3),
 .BR cxl_get_image_loaded (3),
-.BR cxl_get_psl_revision (3)
+.BR cxl_get_psl_revision (3),
+.BR cxl_get_tunneled_ops_supported(3)

--- a/man3/cxl_get_tunneled_ops_supported.3
+++ b/man3/cxl_get_tunneled_ops_supported.3
@@ -1,0 +1,53 @@
+.\" Copyright 2018 IBM Corp.
+.\"
+.TH CXL_GET_TUNNELED_OPS_SUPPORTED 3 2018-04-26 "LIBCXL 1.7" "CXL Manual"
+.SH NAME
+cxl_get_tunneled_ops_supported \- get the status of tunneled operations on the CXL device
+.SH SYNOPSIS
+.B #include <libcxl.h>
+.PP
+.B "int cxl_get_tunneled_ops_supported(struct cxl_adapter_h"
+.BI * adapter ", long *" valp );
+.SH DESCRIPTION
+.BR cxl_get_tunneled_ops_supported ()
+copies the status of tunneled operations on the CXL
+.I adapter
+to the long integer pointed to by
+.IR valp .
+This value will be 1 if tunneled operations are supported in capi mode,
+0 otherwise.
+.PP
+Tunneled operations (atomics and as_notify) are supported on POWER9.
+Libcxl functions related to as_notify are
+.BR cxl_afu_host_thread_wait (),
+.BR cxl_work_disable_wait (),
+.BR cxl_work_enable_wait ()
+and
+.BR cxl_work_get_tid ().
+.SH RETURN VALUE
+On success, 0 is returned.
+On error, \-1 is returned and
+.I errno
+is set appropriately.
+.SH ERRORS
+.TP
+.B EINVAL
+Invalid argument value.
+.TP
+.B ENODEV
+The kernel does not export the tunneled operations status.
+.TP
+.B ENOMEM
+Insufficient memory.
+.SH SEE ALSO
+.BR cxl (3),
+.BR cxl_adapter_next (3),
+.BR cxl_afu_host_thread_wait (3),
+.BR cxl_get_base_image (3),
+.BR cxl_get_caia_version (3),
+.BR cxl_get_image_loaded (3),
+.BR cxl_get_psl_revision (3),
+.BR cxl_get_timebase_synced (3)
+.BR cxl_work_disable_wait (3),
+.BR cxl_work_enable_wait (3),
+.BR cxl_work_get_tid (3)

--- a/man3/cxl_work_disable_wait.3
+++ b/man3/cxl_work_disable_wait.3
@@ -9,6 +9,9 @@ cxl_work_disable_wait \- indicate that a host thread will not wait
 .B "int cxl_work_disable_wait(struct cxl_ioctl_start_work"
 .BI * work );
 .SH DESCRIPTION
+The tunneled operation as_notify is supported on POWER9. See
+.BR cxl_get_tunneled_ops_supported ().
+.PP
 .BR cxl_work_disable_wait ()
 indicates in the
 .I work
@@ -35,6 +38,7 @@ Invalid argument value.
 .BR cxl (3),
 .BR cxl_afu_attach_work (3),
 .BR cxl_afu_host_thread_wait (3),
+.BR cxl_get_tunneled_ops_supported (3),
 .BR cxl_work_alloc (3),
 .BR cxl_work_enable_wait (3),
 .BR cxl_work_get_tid (3)

--- a/man3/cxl_work_enable_wait.3
+++ b/man3/cxl_work_enable_wait.3
@@ -9,6 +9,9 @@ cxl_work_enable_wait \- indicate that a host thread will wait
 .B "int cxl_work_enable_wait(struct cxl_ioctl_start_work"
 .BI * work );
 .SH DESCRIPTION
+The tunneled operation as_notify is supported on POWER9. See
+.BR cxl_get_tunneled_ops_supported ().
+.PP
 .BR cxl_work_enable_wait ()
 indicates in the
 .I work
@@ -31,6 +34,7 @@ Invalid argument value.
 .BR cxl (3),
 .BR cxl_afu_attach_work (3),
 .BR cxl_afu_host_thread_wait (3),
+.BR cxl_get_tunneled_ops_supported (3),
 .BR cxl_work_alloc (3),
 .BR cxl_work_disable_wait (3),
 .BR cxl_work_get_tid (3)

--- a/man3/cxl_work_get_tid.3
+++ b/man3/cxl_work_get_tid.3
@@ -9,6 +9,9 @@ cxl_work_get_tid \- get the tid of the thread that will wait
 .B "int cxl_work_get_tid(struct cxl_ioctl_start_work"
 .BI * work ", __u16 *" valp );
 .SH DESCRIPTION
+The tunneled operation as_notify is supported on POWER9. See
+.BR cxl_get_tunneled_ops_supported ().
+.PP
 .BR cxl_work_get_tid ()
 copies to the address pointed to by
 .I valp
@@ -39,6 +42,7 @@ Invalid argument value, or AFU context not attached, or wait not enabled
 .BR cxl (3),
 .BR cxl_afu_attach_work (3),
 .BR cxl_afu_host_thread_wait (3),
+.BR cxl_get_tunneled_ops_supported (3),
 .BR cxl_work_disable_wait (3),
 .BR cxl_work_enable_wait (3),
 .BR gettid(2)

--- a/symver.map
+++ b/symver.map
@@ -98,3 +98,8 @@ LIBCXL_1.6 {
 		cxl_work_enable_wait;
 		cxl_work_get_tid;
 } LIBCXL_1.4;
+
+LIBCXL_1.7 {
+	global:
+		cxl_get_tunneled_ops_supported;
+} LIBCXL_1.6;


### PR DESCRIPTION
POWER9 introduces tunneled operations (atomics and as_notify).
This commit adds an api to report the tunneled operations status
of the current platform (via /sys).

Signed-off-by: Philippe Bergheaud <felix@linux.ibm.com>