### PR TITLE
Remove 2 backslashes in shell call

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ HAS_WGET = $(shell /bin/which wget > /dev/null 2>&1 && echo y || echo n)
 HAS_CURL = $(shell /bin/which curl > /dev/null 2>&1 && echo y || echo n)
 
 # Update this to test a single feature from the most recent header we require:
-CHECK_CXL_HEADER_IS_UP_TO_DATE = $(shell /bin/echo -e \\\#include $(1)\\\nint i = CXL_START_WORK_TID\; | \
+CHECK_CXL_HEADER_IS_UP_TO_DATE = $(shell /bin/echo -e \#include $(1)\\\nint i = CXL_START_WORK_TID\; | \
                  $(CC) $(CFLAGS) -Werror -x c -S -o /dev/null - >/dev/null 2>&1 && echo y || echo n)
 
 check_cxl_header:


### PR DESCRIPTION
To avoid make failure on openSUSE and Fedora
for openSUSE: start failing in OBS hardware project
between 2020-04-05 and 2020-04-08
for Fedora: start to fail with Rawhide (F33)

failure because trying to download cxl.h while no network during build.
```

=== openSUSE OBS build:
[  112s] Makefile:28: *** 'cxl.h is non-existant or out of date, Download from http://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/plain/include/uapi/misc/cxl.h and place in /home/abuild/rpmbuild/BUILD/libcxl-1.7/include/misc/cxl.h'.  Stop.
===
=== Fedora koji build:
curl -o include/misc/cxl.h -s http://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/plain/include/uapi/misc/cxl.h
make: *** [Makefile:28: check_cxl_header] Error 6
===

```