### PR TITLE
Makefile: Fix header file detection with latest versions of make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,12 +18,18 @@ all: check_cxl_header $(LIBSONAME) libcxl.so libcxl.a
 HAS_WGET = $(shell /bin/which wget > /dev/null 2>&1 && echo y || echo n)
 HAS_CURL = $(shell /bin/which curl > /dev/null 2>&1 && echo y || echo n)
 
-# Update this to test a single feature from the most recent header we require:
-CHECK_CXL_HEADER_IS_UP_TO_DATE = $(shell /bin/echo -e \\\#include $(1)\\\nint i = CXL_START_WORK_TID\; | \
+# Update this to test a single feature from the most recent header we require.
+#
+# Note that a backward-incompatible change in make 4.3 modified the
+# handling \# in a function invocation, so we define the test code in
+# a separate variable to work around it and keep consistent behavior
+# across all versions of make
+TEST_CODE = '\#include <misc/cxl.h>\nint i = CXL_START_WORK_TID;'
+CHECK_CXL_HEADER_IS_UP_TO_DATE = $(shell /bin/echo -e $(TEST_CODE) | \
                  $(CC) $(CFLAGS) -Werror -x c -S -o /dev/null - >/dev/null 2>&1 && echo y || echo n)
 
 check_cxl_header:
-ifeq ($(call CHECK_CXL_HEADER_IS_UP_TO_DATE,"<misc/cxl.h>"),n)
+ifeq (${CHECK_CXL_HEADER_IS_UP_TO_DATE},n)
 	mkdir -p include/misc
 ifeq (${HAS_WGET},y)
 	$(call Q,WGET include/misc/cxl.h, wget -O include/misc/cxl.h -q https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/plain/include/uapi/misc/cxl.h)


### PR DESCRIPTION
Gnu make 4.3 introduced a backward-incompatible change in its handling
of the escape character before # when calling a function. And it is
used when writing some test code to check the latest version of the
ocxl header file (#include <misc/cxl.h>).
This patch reworks how the test code is passed to the compiler to
avoid complications and be compatible with all version of make.

Signed-off-by: Frederic Barrat <fbarrat@linux.ibm.com>